### PR TITLE
Improvemets to course notifier

### DIFF
--- a/app/mailers/course_notification_mailer.rb
+++ b/app/mailers/course_notification_mailer.rb
@@ -1,9 +1,11 @@
-class CourseNotificationMailer < ActionMailer::Base
 
+class CourseNotificationMailer < ActionMailer::Base
+  include ActionView::Helpers::SanitizeHelper
   def notification_email(params={})
     from = params[:from]
     subject = params[:topic]
-    @mailbody = params[:message]
+    @html_mailbody = params[:message].gsub("\n","<br>")
+    @text_mailbody = strip_tags(params[:message])
     to = params[:to]
     mail(:from => from, :to => to, :subject => subject)
   end

--- a/app/views/course_notification_mailer/notification_email.html.erb
+++ b/app/views/course_notification_mailer/notification_email.html.erb
@@ -1,1 +1,1 @@
-<%= @mailbody %>
+<%= raw @html_mailbody %>

--- a/app/views/course_notification_mailer/notification_email.text.erb
+++ b/app/views/course_notification_mailer/notification_email.text.erb
@@ -1,1 +1,1 @@
-<%= @mailbody %>
+<%= @text_mailbody %>


### PR DESCRIPTION
Sending emails allows full html formatting, but strips it from text version of message.
