### PR TITLE
Fix .DS_Store typo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 /config/extra_fields/*.rb
 !/config/extra_fields/*.example.rb
 /coverage
-.DStore
+.DS_Store
 
 # Eclipse
 /.project


### PR DESCRIPTION
Fix .DS_Store typo in .gitignore. Fixes #222.