### PR TITLE
Fix 'undefined local variable' errors

### DIFF
--- a/lib/ruby_init_script/initscript.erb
+++ b/lib/ruby_init_script/initscript.erb
@@ -4,7 +4,7 @@ require 'shellwords'
 %>
 
 ### BEGIN INIT INFO
-# Provides:             <%= name %>
+# Provides:             <%= _name %>
 # Required-Start:       $local_fs $remote_fs $network $syslog
 # Required-Stop:        $local_fs $remote_fs $network $syslog
 # Default-Start:        2 3 4 5
@@ -12,20 +12,20 @@ require 'shellwords'
 # Short-Description:    <%= short_description %>
 ### END INIT INFO
 
-<% for key, value in env %>
+<% for key, value in _env %>
 export <%= key %>=<%= Shellwords.escape(value) %>
 <% end %>
 
 <%
-   command = [Shellwords.escape(ruby_path), Shellwords.escape(executable_path), "$1"].join(' ')
-   if user != 'root'
-     command = "su -c \"#{command}\" #{user}"
+   command = [Shellwords.escape(_ruby_path), Shellwords.escape(_executable_path), "$1"].join(' ')
+   if _user != 'root'
+     command = "su -c \"#{command}\" #{_user}"
    end
 %>
 
 case "$1" in
   start|stop|restart|status)
-    cd <%= Shellwords.escape(working_dir) %>
+    cd <%= Shellwords.escape(_working_dir) %>
     <%= command %>
     ;;
   *)


### PR DESCRIPTION
52c15d4 Changed some template bindings (get_binding), causing
rake background_daemon:init:install to fail with:

        'undefined local variable or method `name'...'
        'undefined local variable or method `env'...'

And so on. I renamed the template variables to reflect the changes in
the previous commit