### PR TITLE
Migrate courses to organizations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 require 'version'
+require 'version'
 require 'twitter-bootstrap-breadcrumbs'
 
 # Base class for all controllers.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 require 'version'
-require 'version'
 require 'twitter-bootstrap-breadcrumbs'
 
 # Base class for all controllers.

--- a/app/controllers/breadcrumb_helpers.rb
+++ b/app/controllers/breadcrumb_helpers.rb
@@ -4,7 +4,7 @@
 # See https://github.com/weppos/breadcrumbs_on_rails
 module BreadcrumbHelpers # Included in ApplicationController
   def add_course_breadcrumb
-    add_breadcrumb "Course #{@course.name}", course_path(@course)
+    add_breadcrumb "Course #{@course.name}", organization_course_path(@organization, @course)
   end
 
   def add_exercise_breadcrumb

--- a/app/controllers/course_notifications_controller.rb
+++ b/app/controllers/course_notifications_controller.rb
@@ -1,6 +1,7 @@
 # Handles emailing notification to every participant
 class CourseNotificationsController < ApplicationController
   before_action :auth
+  before_action :set_organization
 
   def new
     @notifier ||= CourseNotification.new
@@ -16,7 +17,7 @@ class CourseNotificationsController < ApplicationController
 
     if notifier.message.blank?
       flash[:error] = 'Cannot send a blank message.'
-      return redirect_to new_course_course_notifications_path(course)
+      return redirect_to new_organization_course_course_notifications_path(@organization, course)
     end
 
     failed_emails = []
@@ -36,7 +37,7 @@ class CourseNotificationsController < ApplicationController
     end
     msg = 'Mail has been set succesfully'
     msg << " except for the following addresses: #{failed_emails.join(', ')}" unless failed_emails.empty?
-    redirect_to course_path(course), notice: msg
+    redirect_to organization_course_path(@organization, course), notice: msg
   end
 
   private
@@ -47,5 +48,9 @@ class CourseNotificationsController < ApplicationController
 
   def auth
     authorize! :email, CourseNotification
+  end
+
+  def set_organization
+    @organization = Organization.find_by(slug: params[:organization_id])
   end
 end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -4,6 +4,8 @@ require 'course_list'
 require 'exercise_completion_status_generator'
 
 class CoursesController < ApplicationController
+  before_action :set_organization
+
   def index
     ordering = 'hidden, LOWER(name)'
 
@@ -22,7 +24,7 @@ class CoursesController < ApplicationController
 
         data = {
           api_version: ApiVersion::API_VERSION,
-          courses: CourseList.new(current_user, view_context).course_list_data(courses)
+          courses: CourseList.new(current_user, view_context).course_list_data(@organization, courses)
         }
         render json: data.to_json
       end
@@ -48,7 +50,7 @@ class CoursesController < ApplicationController
         return respond_access_denied('Authentication required') if current_user.guest?
         data = {
           api_version: ApiVersion::API_VERSION,
-          course: CourseInfo.new(current_user, view_context).course_data(@course)
+          course: CourseInfo.new(current_user, view_context).course_data(@organization, @course)
         }
         render json: data.to_json
       end
@@ -65,7 +67,7 @@ class CoursesController < ApplicationController
       session[:refresh_report] = e.report
     end
 
-    redirect_to course_path(@course)
+    redirect_to organization_course_path(@course)
   end
 
   def new
@@ -75,11 +77,12 @@ class CoursesController < ApplicationController
 
   def create
     @course = Course.new(course_params[:course])
+    @course.organization = @organization
     authorize! :create, @course
 
     respond_to do |format|
       if @course.save
-        format.html { redirect_to(@course, notice: 'Course was successfully created.') }
+        format.html { redirect_to(organization_course_path(@organization, @course), notice: 'Course was successfully created.') }
       else
         format.html { render action: 'new', notice: 'Course could not be created.' }
       end
@@ -108,5 +111,9 @@ class CoursesController < ApplicationController
       @submissions = @submissions.limit(max_submissions)
       Submission.eager_load_exercises(@submissions)
     end
+  end
+
+  def set_organization
+    @organization = Organization.find_by(slug: params[:organization_id])
   end
 end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -67,7 +67,7 @@ class CoursesController < ApplicationController
       session[:refresh_report] = e.report
     end
 
-    redirect_to organization_course_path(@course)
+    redirect_to organization_course_path
   end
 
   def new

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -1,6 +1,4 @@
 class ExercisesController < ApplicationController
-  before_action :set_organization
-
   def show
     @exercise = Exercise.find(params[:id])
     @course = Course.lock('FOR SHARE').find(@exercise.course_id)

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -4,6 +4,7 @@ class ExercisesController < ApplicationController
   def show
     @exercise = Exercise.find(params[:id])
     @course = Course.lock('FOR SHARE').find(@exercise.course_id)
+    @organization = @course.organization
     authorize! :read, @course
     authorize! :read, @exercise
 
@@ -53,11 +54,5 @@ class ExercisesController < ApplicationController
         render json: data.to_json
       end
     end
-  end
-
-  private
-
-  def set_organization
-    @organization = Organization.find_by(slug: params[:organization_id])
   end
 end

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -1,4 +1,6 @@
 class ExercisesController < ApplicationController
+  before_action :set_organization
+
   def show
     @exercise = Exercise.find(params[:id])
     @course = Course.lock('FOR SHARE').find(@exercise.course_id)
@@ -51,5 +53,11 @@ class ExercisesController < ApplicationController
         render json: data.to_json
       end
     end
+  end
+
+  private
+
+  def set_organization
+    @organization = Organization.find_by(slug: params[:organization_id])
   end
 end

--- a/app/controllers/feedback_answers_controller.rb
+++ b/app/controllers/feedback_answers_controller.rb
@@ -1,4 +1,5 @@
 class FeedbackAnswersController < ApplicationController
+  before_action :set_organization
 
   def index
     if params[:course_id]
@@ -23,7 +24,7 @@ class FeedbackAnswersController < ApplicationController
       add_exercise_breadcrumb
       add_breadcrumb 'Feedback', exercise_feedback_answers_path(@exercise)
     else
-      add_breadcrumb 'Feedback', course_feedback_answers_path(@course)
+      add_breadcrumb 'Feedback', organization_course_feedback_answers_path
     end
 
     @numeric_questions = @course.feedback_questions.where("kind LIKE 'intrange%'").order(:position)
@@ -113,5 +114,11 @@ class FeedbackAnswersController < ApplicationController
         render json: {api_version: ApiVersion::API_VERSION, status: 'ok'}
       end
     end
+  end
+
+  private
+
+  def set_organization
+    @organization = Organization.find_by(slug: params[:organization_id])
   end
 end

--- a/app/controllers/feedback_answers_controller.rb
+++ b/app/controllers/feedback_answers_controller.rb
@@ -1,6 +1,4 @@
 class FeedbackAnswersController < ApplicationController
-  before_action :set_organization
-
   def index
     if params[:course_id]
       @course = Course.find(params[:course_id])
@@ -19,6 +17,7 @@ class FeedbackAnswersController < ApplicationController
       return respond_not_found
     end
 
+    @organization = @course.organization
     add_course_breadcrumb
     if @exercise
       add_exercise_breadcrumb
@@ -114,11 +113,5 @@ class FeedbackAnswersController < ApplicationController
         render json: {api_version: ApiVersion::API_VERSION, status: 'ok'}
       end
     end
-  end
-
-  private
-
-  def set_organization
-    @organization = Organization.find_by(slug: params[:organization_id])
   end
 end

--- a/app/controllers/feedback_questions_controller.rb
+++ b/app/controllers/feedback_questions_controller.rb
@@ -4,6 +4,7 @@
 # TODO: While this is nice, I think feedback questions should live in a conf file in the repo so that the entire course is defined by the repo.
 class FeedbackQuestionsController < ApplicationController
   before_action :get_course
+  before_action :set_organization
 
   def index
     add_course_breadcrumb
@@ -90,5 +91,9 @@ class FeedbackQuestionsController < ApplicationController
     if question.kind == 'intrange'
       question.kind += "[#{params[:intrange_min]}..#{params[:intrange_max]}]"
     end
+  end
+
+  def set_organization
+    @organization = Organization.find_by(slug: params[:organization_id])
   end
 end

--- a/app/controllers/feedback_questions_controller.rb
+++ b/app/controllers/feedback_questions_controller.rb
@@ -28,7 +28,7 @@ class FeedbackQuestionsController < ApplicationController
 
     if @question.save
       flash[:success] = 'Question created.'
-      redirect_to course_feedback_questions_path(@question.course)
+      redirect_to organization_course_feedback_questions_path(@organization, @question.course)
     else
       flash.now[:error] = 'Failed to create question.'
       render :new
@@ -45,6 +45,7 @@ class FeedbackQuestionsController < ApplicationController
   def update
     @question = FeedbackQuestion.find(params[:id])
     @course = @question.course
+    @organization = @course.organization
     authorize! :read, @course
     authorize! :update, @question
 
@@ -53,7 +54,7 @@ class FeedbackQuestionsController < ApplicationController
 
     if @question.save
       flash[:success] = 'Question updated.'
-      redirect_to course_feedback_questions_path(@question.course)
+      redirect_to organization_course_feedback_questions_path(@organization, @question.course)
     else
       flash.now[:error] = 'Failed to update question.'
       render :new
@@ -63,16 +64,17 @@ class FeedbackQuestionsController < ApplicationController
   def destroy
     @question = FeedbackQuestion.find(params[:id])
     @course = @question.course
+    @organization = @course.organization
     authorize! :read, @course
     authorize! :delete, @question
 
     begin
       @question.destroy
       flash[:success] = 'Question deleted.'
-      redirect_to course_feedback_questions_path(@course)
+      redirect_to organization_course_feedback_questions_path(@organization, @course)
     rescue
       flash[:error] = "Failed to delete question: #{$!}"
-      redirect_to course_feedback_questions_path(@course)
+      redirect_to organization_course_feedback_questions_path(@organization, @course)
     end
   end
 

--- a/app/controllers/reviewed_submissions_controller.rb
+++ b/app/controllers/reviewed_submissions_controller.rb
@@ -2,11 +2,12 @@
 class ReviewedSubmissionsController < ApplicationController
   skip_authorization_check
   before_action :check_access
+  before_action :set_organization
 
   def index
     @course = Course.find(params[:course_id])
     add_course_breadcrumb
-    add_breadcrumb 'Reviewed submissions', course_reviewed_submissions_path(@course)
+    add_breadcrumb 'Reviewed submissions', organization_course_reviewed_submissions_path
 
     @submissions = @course.submissions
       .where(reviewed: true)
@@ -19,5 +20,9 @@ class ReviewedSubmissionsController < ApplicationController
 
   def check_access
     respond_access_denied unless current_user.administrator?
+  end
+
+  def set_organization
+    @organization = Organization.find_by(slug: params[:organization_id])
   end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -2,6 +2,8 @@ require 'natsort'
 
 # Presents the code review UI.
 class ReviewsController < ApplicationController
+  before_action :set_organization
+
   def index
     if params[:course_id]
       fetch :course
@@ -14,7 +16,7 @@ class ReviewsController < ApplicationController
       respond_to do |format|
         format.html do
           add_course_breadcrumb
-          add_breadcrumb 'Code reviews', course_reviews_path(@course)
+          add_breadcrumb 'Code reviews', organization_course_reviews_path
           render 'reviews/course_index'
         end
         format.json do
@@ -255,5 +257,11 @@ class ReviewsController < ApplicationController
 
     @review.points = (@review.points_list + new_points + previous_points).uniq.natsort.join(' ')
     submission.points = (submission.points_list + new_points + previous_points).uniq.natsort.join(' ')
+  end
+
+  private
+
+  def set_organization
+    @organization = Organization.find_by(slug: params[:organization_id])
   end
 end

--- a/app/controllers/solutions_controller.rb
+++ b/app/controllers/solutions_controller.rb
@@ -3,6 +3,7 @@ class SolutionsController < ApplicationController
   def show
     @exercise = Exercise.find(params[:exercise_id])
     @course = @exercise.course
+    @organization = @course.organization
 
     add_course_breadcrumb
     add_exercise_breadcrumb

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,12 +1,13 @@
 # Shows the various statistics under /stats.
 class StatsController < ApplicationController
   skip_authorization_check
+  before_action :set_organization
 
   def index
     get_vars
     if @course
       add_course_breadcrumb
-      add_breadcrumb 'Stats', course_stats_path(@course)
+      add_breadcrumb 'Stats', organization_course_stats_path
       course_stats_index
     else
       add_breadcrumb 'Stats', stats_path
@@ -19,8 +20,8 @@ class StatsController < ApplicationController
     page = params[:id]
     if @course
       add_course_breadcrumb
-      add_breadcrumb 'Stats', course_stats_path(@course)
-      add_breadcrumb page.humanize, course_stat_path(@course, page)
+      add_breadcrumb 'Stats', organization_course_stats_path
+      add_breadcrumb page.humanize, organization_course_stat_path(@organization, @course, page)
       course_stats_show(page)
     else
       add_breadcrumb 'Stats', stats_path
@@ -149,5 +150,11 @@ class StatsController < ApplicationController
     else
       fail "Invalid value for parameter #{name}"
     end
+  end
+
+  private
+
+  def set_organization
+    @organization = Organization.find_by(slug: params[:organization_id])
   end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -29,6 +29,7 @@ class SubmissionsController < ApplicationController
     @course ||= @submission.course
     @exercise ||= @submission.exercise
     @files = SourceFileList.for_submission(@submission)
+    @organization = @course.organization
     add_course_breadcrumb
     add_exercise_breadcrumb
     add_submission_breadcrumb

--- a/app/controllers/unlocks_controller.rb
+++ b/app/controllers/unlocks_controller.rb
@@ -23,7 +23,7 @@ class UnlocksController < ApplicationController
     respond_to do |format|
       format.html do
         flash[:success] = 'Exercises unlocked.'
-        redirect_to course_path(@course)
+        redirect_to organization_course_path(@course)
       end
       format.json do
         render json: { status: 'ok' }

--- a/app/controllers/unlocks_controller.rb
+++ b/app/controllers/unlocks_controller.rb
@@ -3,12 +3,13 @@ class UnlocksController < ApplicationController
   def show
     @course = Course.find(params[:course_id])
     authorize! :read, @course
+    @organization = Organization.find_by(slug: params[:organization_id])
     @exercises = @course.unlockable_exercises_for(current_user)
 
     respond_to do |format|
       format.html do
         add_course_breadcrumb
-        add_breadcrumb 'Unlock exercises', course_unlock_path(@course)
+        add_breadcrumb 'Unlock exercises', organization_course_unlock_path
       end
     end
   end
@@ -16,6 +17,7 @@ class UnlocksController < ApplicationController
   def create
     @course = Course.find(params[:course_id])
     authorize! :read, @course
+    @organization = Organization.find_by(slug: params[:organization_id])
     @exercises = @course.unlockable_exercises_for(current_user)
 
     Unlock.unlock_exercises(@exercises, current_user)
@@ -23,7 +25,7 @@ class UnlocksController < ApplicationController
     respond_to do |format|
       format.html do
         flash[:success] = 'Exercises unlocked.'
-        redirect_to organization_course_path(@course)
+        redirect_to organization_course_path(@organization, @course)
       end
       format.json do
         render json: { status: 'ok' }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -32,6 +32,8 @@ class Course < ActiveRecord::Base
   has_many :uncomputed_unlocks, dependent: :delete_all
   has_many :course_notifications, dependent: :delete_all
 
+  belongs_to :organization
+
   def destroy
     # Optimization: delete dependent objects quickly.
     # Rails' :dependent => :delete_all is very slow.

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -19,6 +19,7 @@ class Organization < ActiveRecord::Base
 
   has_many :teacherships, dependent: :destroy
   has_many :teachers, through: :teacherships, source: :user
+  has_many :courses, dependent: :nullify
 
   scope :accepted_organizations, -> { where(acceptance_pending: false).where(rejected: false) }
   scope :pending_organizations, -> { where(acceptance_pending: true) }

--- a/app/views/course_notifications/_form.html.erb
+++ b/app/views/course_notifications/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @notifier, url: course_course_notifications_path do |f| %>
+<%= form_for @notifier, url: organization_course_course_notifications_path do |f| %>
   <%= f.label :topic %>
   <br />
   <%= f.text_field :topic %>

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(@course) do |f| %>
+<%= form_for(@course, url: organization_courses_path) do |f| %>
   <%= render 'shared/error_messages', :target => @course %>
 
   <%= labeled_field("Course name (should not contain whitespace)", f.text_field(:name)) %>

--- a/app/views/courses/_list.html.erb
+++ b/app/views/courses/_list.html.erb
@@ -10,7 +10,7 @@
     <% locals[:courses].each do |course| %>
       <tr class="course <% if course.hidden? %>hidden-course<% end %>">
         <td>
-          <%= link_to course.name, course_path(course) %>
+          <%= link_to course.name, organization_course_path(@organization, course) %>
         </td>
       </tr>
     <% end %>
@@ -20,5 +20,5 @@
 <!--%= use_datatables('table.course-list#' + locals[:list_id], :bPaginate => false, :bFilter => false) %-->
 
 <% if signed_in? %>
-  <div class="alternative-format-links">[<%= link_to "json", "#{courses_path :format => :json, :api_version => ApiVersion::API_VERSION}" %>]</div>
+  <div class="alternative-format-links">[<%= link_to "json", "#{organization_courses_path :format => :json, :api_version => ApiVersion::API_VERSION}" %>]</div>
 <% end %>

--- a/app/views/courses/_list.html.erb
+++ b/app/views/courses/_list.html.erb
@@ -20,5 +20,5 @@
 <!--%= use_datatables('table.course-list#' + locals[:list_id], :bPaginate => false, :bFilter => false) %-->
 
 <% if signed_in? %>
-  <div class="alternative-format-links">[<%= link_to "json", "#{organization_courses_path :format => :json, :api_version => ApiVersion::API_VERSION}" %>]</div>
+  <div class="alternative-format-links">[<%= link_to "json", "#{organization_courses_path organization_id: @organization.slug, format: :json, api_version: ApiVersion::API_VERSION}" %>]</div>
 <% end %>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -28,7 +28,7 @@
 <% if can? :create, Course %>
   <div class="row-fluid">
     <div class="span12">
-      <%= link_to 'Create New Course', new_course_path, class: "btn btn-mini btn-warning" %>
+      <%= link_to 'Create New Course', new_organization_course_path, class: "btn btn-mini btn-warning" %>
     </div>
   </div>
 <% end %>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -12,7 +12,7 @@
 <% end %>
 <div class="row-fluid">
   <div class="span12">
-    <%= render 'list', :locals => { :courses => @ongoing_courses, :list_id => 'ongoing-courses' } %>
+    <%= render 'list', :locals => { organization_id: @organization.slug, courses: @ongoing_courses, list_id: 'ongoing-courses' } %>
   </div>
 </div>
 
@@ -20,7 +20,7 @@
   <h3>Expired courses</h3>
   <div class="row-fluid">
     <div class="span12">
-      <%= render 'list', :locals => { :courses => @expired_courses, :list_id => 'expired-courses' } %>
+      <%= render 'list', :locals => { organization_id: @organization.slug, courses: @expired_courses, list_id: 'expired-courses' } %>
     </div>
   </div>
 <% end %>
@@ -28,7 +28,7 @@
 <% if can? :create, Course %>
   <div class="row-fluid">
     <div class="span12">
-      <%= link_to 'Create New Course', new_organization_course_path, class: "btn btn-mini btn-warning" %>
+      <%= link_to 'Create New Course', new_organization_course_path(@organization), class: "btn btn-mini btn-warning" %>
     </div>
   </div>
 <% end %>

--- a/app/views/courses/new.html.erb
+++ b/app/views/courses/new.html.erb
@@ -3,6 +3,6 @@
 <%= render 'form' %>
 
 <div class="link-back">
-  <%= link_to 'Back', courses_path %>
+  <%= link_to 'Back', organization_courses_path %>
 </div>
 

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -8,9 +8,9 @@
       <% end %>
 
       <ul>
-        <li><%= link_to 'View points', course_points_path(@course) %></li>
+        <li><%= link_to 'View points', organization_course_points_path(@organization, @course) %></li>
         <% if can? :view_code_reviews, @course %>
-          <li><%= link_to 'View code reviews', course_reviews_path(@course) %></li>
+          <li><%= link_to 'View code reviews', organization_course_reviews_path(@organization, @course) %></li>
         <% end %>
       </ul>
       <% if can? :read, :course_information %>
@@ -48,8 +48,8 @@
 
           <li>
             Number of submissions (from <span title="administrators and specially marked test user accounts are excluded">actual users</span>): <%= @total_submissions %>
-            (stats <%= link_to 'over time', course_stat_path(@course, 'submissions') %>,
-             <%= link_to 'by hour', course_stat_path(@course, 'submission_times') %>)
+            (stats <%= link_to 'over time', organization_course_stat_path(@organization, @course, 'submissions') %>,
+             <%= link_to 'by hour', organization_course_stat_path(@organization, @course, 'submission_times') %>)
           </li>
 
           <% if @course.spreadsheet_key %>
@@ -59,7 +59,7 @@
             </li>
           <% end %>
           <li>
-            <%= link_to 'Send message to every participant', new_course_course_notifications_path(@course) %>
+            <%= link_to 'Send message to every participant', new_organization_course_course_notifications_path(@organization, @course) %>
           </li>
         </ul>
 
@@ -83,17 +83,17 @@
         <% end %>
 
         <ul>
-          <li><%= link_to 'View feedback', course_feedback_answers_path(@course)%></li>
-          <li><%= link_to 'Manage feedback questions', course_feedback_questions_path(@course) %></li>
+          <li><%= link_to 'View feedback', organization_course_feedback_answers_path(@organization, @course)%></li>
+          <li><%= link_to 'Manage feedback questions', organization_course_feedback_questions_path(@organization, @course) %></li>
         </ul>
       <% end %>
       <% if can? :refresh, @course %>
-        <%= link_to 'Refresh', refresh_course_path(@course), class: "btn btn-warning btn-mini" %>
+        <%= link_to 'Refresh', refresh_organization_course_path(@organization, @course), class: "btn btn-warning btn-mini" %>
       <% end %>
       <% unlockables = @course.unlockable_exercises_for(current_user) %>
       <% unless unlockables.empty? %>
         <p>
-          You can <%= link_to "unlock #{pluralize(unlockables.count, 'new exercise')}", course_unlock_path(@course) %>.
+          You can <%= link_to "unlock #{pluralize(unlockables.count, 'new exercise')}", organization_course_unlock_path(@organization, @course) %>.
         </p>
       <% end %>
     </div>
@@ -115,7 +115,7 @@
         <% if @total_submissions > @submissions.count %>
           <p>
             Only showing <%= @submissions.count %> of <%= @total_submissions %>
-            <%= link_to "(show all)", course_submissions_path(@course) %>.
+            <%= link_to "(show all)", organization_course_submissions_path(@organization, @course) %>.
           </p>
         <% end %>
         <div>

--- a/app/views/courses/stats/index.html.erb
+++ b/app/views/courses/stats/index.html.erb
@@ -1,5 +1,5 @@
 <h1>Course stats</h1>
 <ul>
-  <li><%= link_to "Submissions over time", course_stat_path(@course, 'submissions') %></li>
-  <li><%= link_to "Submissions per hour", course_stat_path(@course, 'submission_times') %></li>
+  <li><%= link_to "Submissions over time", organization_course_stat_path(@organization, @course, 'submissions') %></li>
+  <li><%= link_to "Submissions per hour", organization_course_stat_path(@organization, @course, 'submission_times') %></li>
 </ul>

--- a/app/views/feedback_questions/_form.html.erb
+++ b/app/views/feedback_questions/_form.html.erb
@@ -7,7 +7,7 @@ else
 end
 
 if question.new_record?
-  url = course_feedback_questions_path(question.course)
+  url = organization_course_feedback_questions_path(@organization, question.course)
 else
   url = feedback_question_path(question)
 end

--- a/app/views/feedback_questions/index.html.erb
+++ b/app/views/feedback_questions/index.html.erb
@@ -28,5 +28,5 @@
 <% end %>
 
 <div class="actions">
-  <%= link_to 'Add question', new_course_feedback_question_path(@course) %>
+  <%= link_to 'Add question', new_organization_course_feedback_question_path %>
 </div>

--- a/app/views/points/index.html.erb
+++ b/app/views/points/index.html.erb
@@ -95,4 +95,4 @@
   </table>
 <% end %>
 
-<div class="alternative-format-links">[<%= link_to('csv', course_points_path(@course, :sort_by => params[:sort_by], :format => 'csv')) %>]</div>
+<div class="alternative-format-links">[<%= link_to('csv', organization_course_points_path(@organization, @course, :sort_by => params[:sort_by], :format => 'csv')) %>]</div>

--- a/app/views/points/show.html.erb
+++ b/app/views/points/show.html.erb
@@ -5,18 +5,18 @@
 
 <ul>
   <li>
-    <%= link_to 'Back to summary', course_points_path(@course) %>
+    <%= link_to 'Back to summary', organization_course_points_path(@organization, @course) %>
   </li>
   <li>
     <% if params[:sort_by].blank? %>
-      <%= link_to 'Sort by points', course_point_path(@course, @sheetname, :sort_by => 'points') %>
+      <%= link_to 'Sort by points', organization_course_point_path(@organization, @course, @sheetname, :sort_by => 'points') %>
     <% else %>
-      <%= link_to 'Sort by username', course_point_path(@course, @sheetname) %>
+      <%= link_to 'Sort by username', organization_course_point_path(@organization, @course, @sheetname) %>
     <% end %>
   </li>
   <% if can? :refresh_gdocs_spreadsheet, @course %>
     <li>
-      <%= link_to 'Refresh Google Docs worksheet', refresh_gdocs_course_point_path(@course, @sheetname) %>
+      <%= link_to 'Refresh Google Docs worksheet', refresh_gdocs_organization_course_point_path(@organization, @course, @sheetname) %>
     </li>
   <% end %>
 </ul>

--- a/app/views/reviews/course_index.html.erb
+++ b/app/views/reviews/course_index.html.erb
@@ -4,7 +4,7 @@
   <section>
     <h2>Administration</h2>
 
-    <p><%= link_to 'View all reviewed submissions', course_reviewed_submissions_path(@course) %></p>
+    <p><%= link_to 'View all reviewed submissions', organization_course_reviewed_submissions_path %></p>
 
     <% subs = @course.submissions_to_review.order('created_at DESC') %>
     <h3>Submissions to review</h3>

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -51,5 +51,5 @@
 <%= show_submission_list([], :invoke_datatables => false) %>
 
 <div class="link-back">
-  <%= link_to 'Back', course_path(@course) %>
+  <%= link_to 'Back', organization_course_path(@course) %>
 </div>

--- a/app/views/unlocks/show.html.erb
+++ b/app/views/unlocks/show.html.erb
@@ -11,4 +11,4 @@
   <% end %>
 </ul>
 
-<%= button_to "Unlock these exercises", course_unlock_path(@course) %>
+<%= button_to "Unlock these exercises", organization_course_unlock_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,32 @@ TmcServer::Application.routes.draw do
     end
 
     resources :teachers, only: [:index, :new, :create, :destroy]
+
+    resources :courses do
+      member do
+        get 'refresh'
+        post 'refresh'
+      end
+
+      resources :points, only: [:index, :show] do
+        member do
+          get 'refresh_gdocs'
+        end
+      end
+
+      resources :stats, only: [:index, :show]
+      resources :exercise_status, only: [:show]
+      resources :exercises, only: [:index]
+      resources :submissions, only: [:index]
+      resources :reviewed_submissions, only: [:index]
+      resources :feedback_questions, only: [:index, :new, :create]
+      resources :feedback_answers, only: [:index]
+      get 'feedback_answers/chart/:type' => 'feedback_answers_charts#show', :as => 'feedback_answers_chart'
+      resources :reviews, only: [:index]
+      resource :unlock, only: [:show, :create]
+      resource :course_notifications, only: [:create, :index, :show, :new]
+    end
+
   end
 
   resources :course_templates, except: :show
@@ -40,31 +66,6 @@ TmcServer::Application.routes.draw do
   resources :password_reset_keys
   get '/reset_password/:code' => 'password_reset_keys#show', :as => 'reset_password'
   delete '/reset_password/:code' => 'password_reset_keys#destroy'
-
-  resources :courses do
-    member do
-      get 'refresh'
-      post 'refresh'
-    end
-
-    resources :points, only: [:index, :show] do
-      member do
-        get 'refresh_gdocs'
-      end
-    end
-
-    resources :stats, only: [:index, :show]
-    resources :exercise_status, only: [:show]
-    resources :exercises, only: [:index]
-    resources :submissions, only: [:index]
-    resources :reviewed_submissions, only: [:index]
-    resources :feedback_questions, only: [:index, :new, :create]
-    resources :feedback_answers, only: [:index]
-    get 'feedback_answers/chart/:type' => 'feedback_answers_charts#show', :as => 'feedback_answers_chart'
-    resources :reviews, only: [:index]
-    resource :unlock, only: [:show, :create]
-    resource :course_notifications, only: [:create, :index, :show, :new]
-  end
 
   resources :exercises, only: [:show] do
     resources :submissions, only: [:create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,5 +102,5 @@ TmcServer::Application.routes.draw do
     end
   end
 
-  root to: 'courses#index'
+  root to: 'organizations#index'
 end

--- a/db/migrate/20150527103134_course_belongs_to_organization.rb
+++ b/db/migrate/20150527103134_course_belongs_to_organization.rb
@@ -1,5 +1,27 @@
 class CourseBelongsToOrganization < ActiveRecord::Migration
   def change
     add_reference :courses, :organization, index: true, foreign_key: true
+    default_organization = Organization.find_by slug: 'default'
+    reversible do |dir|
+      dir.up do
+        orphans = Course.select { |c| c.organization.nil? }
+        unless orphans.empty?
+          if default_organization.nil?
+            default_organization = Organization.create name: 'Default',
+                                               information: 'Temporary organization used for migrating purposes',
+                                               slug: 'default',
+                                               acceptance_pending: false
+          end
+          orphans.each do |c|
+            c.organization = default_organization
+            c.save
+          end
+        end
+      end
+      dir.down do
+        Course.all.each { |c| c.organization = nil }
+        default_organization.destroy unless default_organization.nil?
+      end
+    end
   end
 end

--- a/db/migrate/20150527103134_course_belongs_to_organization.rb
+++ b/db/migrate/20150527103134_course_belongs_to_organization.rb
@@ -1,0 +1,5 @@
+class CourseBelongsToOrganization < ActiveRecord::Migration
+  def change
+    add_reference :courses, :organization, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150526082930) do
+ActiveRecord::Schema.define(version: 20150527103134) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,7 +72,10 @@ ActiveRecord::Schema.define(version: 20150526082930) do
     t.boolean  "locked_exercise_points_visible", default: true,     null: false
     t.text     "description"
     t.string   "paste_visibility"
+    t.integer  "organization_id"
   end
+
+  add_index "courses", ["organization_id"], name: "index_courses_on_organization_id", using: :btree
 
   create_table "exercises", force: true do |t|
     t.string   "name"

--- a/lib/course_info.rb
+++ b/lib/course_info.rb
@@ -7,7 +7,7 @@ class CourseInfo
     @course_list = CourseList.new(user, helpers)
   end
 
-  def course_data(course)
+  def course_data(organization, course)
     exercises = course.exercises.includes(:course, :available_points).to_a.natsort_by(&:name)
 
     @unlocked_exercises = course.unlocks
@@ -24,8 +24,8 @@ class CourseInfo
       ex.set_submissions_by(@user, submissions_by_exercise[ex.name] || [])
     end
 
-    @course_list.course_data(course).merge(unlockables: course.unlockable_exercises_for(@user).map(&:name).natsort,
-                                           exercises: exercises.map { |ex| exercise_data(ex) }.reject(&:nil?))
+    @course_list.course_data(organization, course).merge(unlockables: course.unlockable_exercises_for(@user).map(&:name).natsort,
+                                                         exercises: exercises.map { |ex| exercise_data(ex) }.reject(&:nil?))
   end
 
   private

--- a/lib/course_list.rb
+++ b/lib/course_list.rb
@@ -5,17 +5,17 @@ class CourseList
     @helpers = helpers
   end
 
-  def course_list_data(courses)
-    courses.map { |c| course_data(c) }
+  def course_list_data(organization, courses)
+    courses.map { |c| course_data(organization, c) }
   end
 
-  def course_data(course)
+  def course_data(organization, course)
     {
       id: course.id,
       name: course.name,
-      details_url: @helpers.course_url(course, format: :json),
-      unlock_url: @helpers.course_unlock_url(course, format: :json),
-      reviews_url: @helpers.course_reviews_url(course, format: :json),
+      details_url: @helpers.organization_course_url(organization, course, format: :json),
+      unlock_url: @helpers.organization_course_unlock_url(organization, course, format: :json),
+      reviews_url: @helpers.organization_course_reviews_url(organization, course, format: :json),
       comet_url: CometServer.get.client_url,
       spyware_urls: SiteSetting.value('spyware_servers')
     }

--- a/spec/controllers/course_notifications_controller_spec.rb
+++ b/spec/controllers/course_notifications_controller_spec.rb
@@ -2,16 +2,22 @@ require 'spec_helper'
 require 'cancan/matchers'
 
 describe CourseNotificationsController, type: :controller do
+  before :each do
+    @organization = FactoryGirl.create(:accepted_organization)
+    @course = FactoryGirl.create(:course)
+    @course.organization = @organization
+  end
+
   let(:topic) { 'Hi all' }
   let(:message) { 'A long message to every participant on some course...' }
-  let(:course) { FactoryGirl.create(:course) }
   let(:params) do
     {
       course_notification: {
         topic: topic,
         message: message
       },
-      course_id: course.id
+      organization_id: @organization.slug,
+      course_id: @course.id
     }
   end
 
@@ -27,7 +33,7 @@ describe CourseNotificationsController, type: :controller do
     expect { post :create, params }.to raise_error
   end
 
-  describe 'for an admin user ' do
+  describe 'for an admin user' do
     let(:admin) { FactoryGirl.create(:admin, email: 'admin@mydomain.com') }
     before do
       controller.current_user = admin
@@ -35,17 +41,17 @@ describe CourseNotificationsController, type: :controller do
 
     it 'redirects to the course page' do
       post :create, params
-      expect(response).to redirect_to(course_path(course))
+      expect(response).to redirect_to(organization_course_path(@organization, @course))
     end
 
     it 'sends a email for every participant on course' do
       # submissions and points are added so that the user is considered to be on the course
       user = FactoryGirl.create(:user, email: 'student@some.edu.fi')
-      sub1 = FactoryGirl.create(:submission, user: user, course: course)
+      sub1 = FactoryGirl.create(:submission, user: user, course: @course)
       user2 = FactoryGirl.create(:user, email: 'std@myschool.fi')
-      sub2 = FactoryGirl.create(:submission, user: user2, course: course)
-      aw1 = FactoryGirl.create(:awarded_point, user_id: user.id, course_id: course.id)
-      aw2 = FactoryGirl.create(:awarded_point, user_id: user2.id, course_id: course.id)
+      sub2 = FactoryGirl.create(:submission, user: user2, course: @course)
+      aw1 = FactoryGirl.create(:awarded_point, user_id: user.id, course_id: @course.id)
+      aw2 = FactoryGirl.create(:awarded_point, user_id: user2.id, course_id: @course.id)
 
       expect { post :create, params }.to change(ActionMailer::Base.deliveries, :size).by(2)
 
@@ -60,11 +66,11 @@ describe CourseNotificationsController, type: :controller do
 
     it "doesn't crash if some email addresses are invalid" do
       user = FactoryGirl.create(:user, email: 'student@some.edu.fi')
-      sub1 = FactoryGirl.create(:submission, user: user, course: course)
+      sub1 = FactoryGirl.create(:submission, user: user, course: @course)
       user2 = FactoryGirl.create(:user, email: 'std  @ myschool . fi') # The invalid address
-      sub2 = FactoryGirl.create(:submission, user: user2, course: course)
-      aw1 = FactoryGirl.create(:awarded_point, user_id: user.id, course_id: course.id)
-      aw2 = FactoryGirl.create(:awarded_point, user_id: user2.id, course_id: course.id)
+      sub2 = FactoryGirl.create(:submission, user: user2, course: @course)
+      aw1 = FactoryGirl.create(:awarded_point, user_id: user.id, course_id: @course.id)
+      aw2 = FactoryGirl.create(:awarded_point, user_id: user2.id, course_id: @course.id)
 
       expect { post :create, params }.to change(ActionMailer::Base.deliveries, :size).by(1)
 
@@ -76,7 +82,7 @@ describe CourseNotificationsController, type: :controller do
     it 'refuses to send a blank message' do
       params[:course_notification][:message] = ''
       post :create, params
-      expect(response).to redirect_to(new_course_course_notifications_path(course))
+      expect(response).to redirect_to(new_organization_course_course_notifications_path(@organization, @course))
       expect(flash[:error]).not_to be_empty
     end
   end

--- a/spec/controllers/course_templates_controller_spec.rb
+++ b/spec/controllers/course_templates_controller_spec.rb
@@ -10,7 +10,7 @@ describe CourseTemplatesController, type: :controller do
   let(:valid_attributes) do
     {
       name: 'TestTemplateCourse',
-      source_url: 'git@example.com',
+      source_url: 'http://example.com',
       title: 'Test Template Title'
     }
   end

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -15,7 +15,7 @@ describe CoursesController, type: :controller do
         FactoryGirl.create(:course, name: 'AnotherTestCourse')
       ]
 
-      get :index
+      get :index, organization_id: @organization.slug
 
       expect(assigns(:ongoing_courses).map(&:name)).to eq(%w(AnotherTestCourse SomeTestCourse))
       expect(assigns(:expired_courses).map(&:name)).to eq(['ExpiredCourse'])

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe CoursesController, type: :controller do
   before(:each) do
     @user = FactoryGirl.create(:user)
+    @organization = FactoryGirl.create(:accepted_organization)
   end
 
   describe 'GET index' do
@@ -24,7 +25,8 @@ describe CoursesController, type: :controller do
       def get_index_json(options = {})
         options = {
           format: 'json',
-          api_version: ApiVersion::API_VERSION
+          api_version: ApiVersion::API_VERSION,
+          organization_id: @organization.slug
         }.merge options
         @request.env['HTTP_AUTHORIZATION'] = 'Basic ' + Base64.encode64("#{@user.login}:#{@user.password}")
         get :index, options
@@ -62,7 +64,7 @@ describe CoursesController, type: :controller do
         sub1 = FactoryGirl.create(:submission, user: user1, course: @course)
         sub2 = FactoryGirl.create(:submission, user: user2, course: @course)
 
-        get :show, id: @course.id
+        get :show, organization_id: @organization.slug, id: @course.id
 
         expect(assigns['submissions']).to include(sub1)
         expect(assigns['submissions']).to include(sub2)
@@ -78,7 +80,7 @@ describe CoursesController, type: :controller do
         FactoryGirl.create(:submission, course: @course)
         FactoryGirl.create(:submission, course: @course)
 
-        get :show, id: @course.id
+        get :show, organization_id: @organization.slug, id: @course.id
 
         expect(assigns['submissions']).to be_nil
       end
@@ -93,7 +95,7 @@ describe CoursesController, type: :controller do
         my_sub = FactoryGirl.create(:submission, user: @user, course: @course)
         other_guys_sub = FactoryGirl.create(:submission, user: other_user, course: @course)
 
-        get :show, id: @course.id
+        get :show, organization_id: @organization.slug, id: @course.id
 
         expect(assigns['submissions']).to include(my_sub)
         expect(assigns['submissions']).not_to include(other_guys_sub)
@@ -112,7 +114,8 @@ describe CoursesController, type: :controller do
         options = {
           format: 'json',
           api_version: ApiVersion::API_VERSION,
-          id: @course.id.to_s
+          id: @course.id.to_s,
+          organization_id: @organization.slug
         }.merge options
         @request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(@user.login, @user.password)
         get :show, options
@@ -205,19 +208,19 @@ describe CoursesController, type: :controller do
 
     describe 'with valid parameters' do
       it 'creates the course' do
-        post :create, course: { name: 'NewCourse', source_url: 'git@example.com' }
+        post :create, organization_id: @organization.slug, course: { name: 'NewCourse', source_url: 'git@example.com' }
         expect(Course.last.source_url).to eq('git@example.com')
       end
 
       it 'redirects to the created course' do
-        post :create, course: { name: 'NewCourse', source_url: 'git@example.com' }
-        expect(response).to redirect_to(Course.last)
+        post :create, organization_id: @organization.slug, course: { name: 'NewCourse', source_url: 'git@example.com' }
+        expect(response).to redirect_to(organization_course_path(@organization, Course.last))
       end
     end
 
     describe 'with invalid parameters' do
       it 're-renders the course creation form' do
-        post :create, course: { name: 'invalid name with spaces' }
+        post :create, organization_id: @organization.slug, course: { name: 'invalid name with spaces' }
         expect(response).to render_template('new')
         expect(assigns(:course).name).to eq('invalid name with spaces')
       end

--- a/spec/controllers/exercise_status_controller_spec.rb
+++ b/spec/controllers/exercise_status_controller_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe ExerciseStatusController, type: :controller do
   before :each do
+    @organization = FactoryGirl.create(:accepted_organization)
     @course = FactoryGirl.create(:course)
+    @course.organization = @organization
     @exercise = FactoryGirl.create(:exercise, course: @course)
     @exercise2 = FactoryGirl.create(:exercise, course: @course)
     @exercise3 = FactoryGirl.create(:exercise, course: @course)
@@ -38,7 +40,7 @@ describe ExerciseStatusController, type: :controller do
       end
 
       def do_get
-        get :show, course_id: @course.id, id: @user.id, format: :json, api_version: ApiVersion::API_VERSION
+        get :show, organization_id: @organization.slug, course_id: @course.id, id: @user.id, format: :json, api_version: ApiVersion::API_VERSION
       end
 
       it 'should show completition status for submitted exercises' do

--- a/spec/controllers/exercises_controller_spec.rb
+++ b/spec/controllers/exercises_controller_spec.rb
@@ -2,11 +2,15 @@ require 'spec_helper'
 
 describe ExercisesController, type: :controller do
   describe 'GET show' do
-    let!(:course) { FactoryGirl.create(:course) }
-    let!(:exercise) { FactoryGirl.create(:exercise, course: course) }
+    before :each do
+      @organization = FactoryGirl.create(:accepted_organization)
+      @course = FactoryGirl.create(:course)
+      @course.organization = @organization
+    end
+    let!(:exercise) { FactoryGirl.create(:exercise, course: @course) }
 
     def get_show
-      get :show, id: exercise.id
+      get :show, organization_id: @organization.slug, id: exercise.id
     end
 
     describe 'for guests' do
@@ -22,8 +26,8 @@ describe ExercisesController, type: :controller do
         controller.current_user = user
       end
       it "should not show the user's submissions" do
-        s1 = FactoryGirl.create(:submission, course: course, exercise: exercise, user: user)
-        s2 = FactoryGirl.create(:submission, course: course, exercise: exercise)
+        s1 = FactoryGirl.create(:submission, course: @course, exercise: exercise, user: user)
+        s2 = FactoryGirl.create(:submission, course: @course, exercise: exercise)
 
         get_show
 
@@ -38,8 +42,8 @@ describe ExercisesController, type: :controller do
         controller.current_user = FactoryGirl.create(:admin)
       end
       it 'should show all submissions' do
-        s1 = FactoryGirl.create(:submission, course: course, exercise: exercise)
-        s2 = FactoryGirl.create(:submission, course: course, exercise: exercise)
+        s1 = FactoryGirl.create(:submission, course: @course, exercise: exercise)
+        s2 = FactoryGirl.create(:submission, course: @course, exercise: exercise)
         irrelevant = FactoryGirl.create(:submission)
 
         get_show

--- a/spec/controllers/points_controller_spec.rb
+++ b/spec/controllers/points_controller_spec.rb
@@ -4,7 +4,9 @@ require 'spec_helper'
 describe PointsController, type: :controller do
   render_views
   before :each do
+    @organization = FactoryGirl.create(:accepted_organization)
     @course = FactoryGirl.create(:course)
+    @course.organization = @organization
     @sheetname = 'testsheet'
     @exercise = FactoryGirl.create(:exercise, course: @course,
                                               gdocs_sheet: @sheetname)
@@ -31,22 +33,23 @@ describe PointsController, type: :controller do
       end
 
       it 'should show a page' do
-        get :show, course_id: @course.id, id: @sheetname
+        get :show, organization_id: @organization.slug,
+            course_id: @course.id, id: @sheetname
         expect(response).to be_success
       end
 
       it 'should contain @user login' do
-        get :show, course_id: @course.id, id: @sheetname
+        get :show, organization_id: @organization.slug, course_id: @course.id, id: @sheetname
         expect(response.body).to have_content(@user.login)
       end
 
       it 'should contain available point name' do
-        get :show, course_id: @course.id, id: @sheetname
+        get :show, organization_id: @organization.slug, course_id: @course.id, id: @sheetname
         expect(response.body).to have_content(@available_point.name)
       end
 
       it 'should contain a success marker' do
-        get :show, course_id: @course.id, id: @sheetname
+        get :show, organization_id: @organization.slug, course_id: @course.id, id: @sheetname
         expect(response.body).to have_content('✔')
       end
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -28,6 +28,7 @@ FactoryGirl.define do
   factory :course, class: Course do
     sequence(:name) { |n| "course#{n}" }
     source_url 'git@example.com'
+    organization
   end
 
   factory :exercise do

--- a/spec/integration/admin_usecases_spec.rb
+++ b/spec/integration/admin_usecases_spec.rb
@@ -4,6 +4,8 @@ describe 'The system (used by an instructor for administration)', type: :request
   include IntegrationTestActions
 
   before :each do
+    @organization = FactoryGirl.create(:accepted_organization, slug: 'slug')
+
     visit '/'
     @user = FactoryGirl.create(:admin, password: 'xooxer')
     log_in_as(@user.login, 'xooxer')
@@ -13,26 +15,26 @@ describe 'The system (used by an instructor for administration)', type: :request
   end
 
   it 'should allow using a git repo as a source for a new course' do
-    create_new_course(name: 'mycourse', source_backend: 'git', source_url: @repo_path)
+    create_new_course(name: 'mycourse', source_backend: 'git', source_url: @repo_path, organization_slug: @organization.slug)
   end
 
   it "should show all exercises pushed to the course's git repo" do
-    create_new_course(name: 'mycourse', source_backend: 'git', source_url: @repo_path)
+    create_new_course(name: 'mycourse', source_backend: 'git', source_url: @repo_path, organization_slug: @organization.slug)
     course = Course.find_by_name!('mycourse')
 
     repo = clone_course_repo(course)
     repo.copy_simple_exercise('MyExercise', deadline: (Date.today - 1.day).to_s)
     repo.add_commit_push
 
-    manually_refresh_course('mycourse')
+    manually_refresh_course('mycourse', @organization.slug)
 
-    visit '/courses'
+    visit "/org/#{@organization.slug}/courses"
     click_link 'mycourse'
     expect(page).to have_content('MyExercise')
   end
 
   it 'should allow rerunning individual submissions' do
-    setup = SubmissionTestSetup.new(solve: true, save: true)
+    setup = SubmissionTestSetup.new(solve: true, save: true, organization: @organization)
     setup.make_zip
     setup.submission.processed = true
     setup.submission.pretest_error = 'some funny error'

--- a/spec/integration/broken_utf8_spec.rb
+++ b/spec/integration/broken_utf8_spec.rb
@@ -6,7 +6,8 @@ describe 'The system, receiving submissions with broken UTF-8', type: :request, 
   before :each do
     repo_path = Dir.pwd + '/remote_repo'
     create_bare_repo(repo_path)
-    @course = Course.create!(name: 'mycourse', source_backend: 'git', source_url: repo_path)
+    @organization = FactoryGirl.create(:accepted_organization, slug: 'slug')
+    @course = Course.create!(name: 'mycourse', source_backend: 'git', source_url: repo_path, organization_id: @organization.id)
     @repo = clone_course_repo(@course)
     @repo.copy(FixtureExercise.fixture_exercises_root + '/BrokenUtf8')
     @repo.add_commit_push
@@ -15,7 +16,7 @@ describe 'The system, receiving submissions with broken UTF-8', type: :request, 
 
     @user = FactoryGirl.create(:user, password: 'xooxer')
 
-    visit '/'
+    visit '/org/slug/courses'
     log_in_as(@user.login, 'xooxer')
     click_link 'mycourse'
 

--- a/spec/integration/feedback/feedback_question_management_spec.rb
+++ b/spec/integration/feedback/feedback_question_management_spec.rb
@@ -4,13 +4,14 @@ describe 'Feedback question management', type: :request, integration: true do
   include IntegrationTestActions
 
   before :each do
+    @organization = FactoryGirl.create(:accepted_organization, slug: 'slug')
     @user = FactoryGirl.create(:admin, password: 'xooxer')
     visit '/'
     log_in_as(@user.login, 'xooxer')
 
-    create_new_course name: 'TheCourse', source_url: Dir.pwd + '/unused'
+    create_new_course name: 'TheCourse', source_url: Dir.pwd + '/unused', organization_slug: @organization.slug
 
-    visit '/'
+    visit '/org/slug/courses'
     click_link 'TheCourse'
     click_link 'Manage feedback questions'
   end

--- a/spec/integration/feedback/viewing_feedback_spec.rb
+++ b/spec/integration/feedback/viewing_feedback_spec.rb
@@ -4,14 +4,15 @@ describe 'Viewing feedback', type: :request, integration: true do
   include IntegrationTestActions
 
   before :each do
+    @organization = FactoryGirl.create(:accepted_organization, slug: 'slug')
     @user = FactoryGirl.create(:admin, password: 'xooxer')
     visit '/'
     log_in_as(@user.login, 'xooxer')
 
-    @course = FactoryGirl.create(:course)
+    @course = FactoryGirl.create(:course, organization: @organization)
     @question = FactoryGirl.create(:feedback_question, course: @course)
 
-    visit '/'
+    visit '/org/slug/courses'
   end
 
   it 'should be possible per-course' do
@@ -33,7 +34,7 @@ describe 'Viewing feedback', type: :request, integration: true do
     click_link 'View feedback'
     expect(page).to have_content('this is the answer')
 
-    visit '/'
+    visit '/org/slug/courses'
     click_link @course.name
     click_link @ex2.name
     click_link 'View feedback'

--- a/spec/integration/personal_deadlines_spec.rb
+++ b/spec/integration/personal_deadlines_spec.rb
@@ -6,7 +6,8 @@ describe 'Personal deadlines', type: :request, integration: true do
   before :each do
     repo_path = Dir.pwd + '/remote_repo'
     create_bare_repo(repo_path)
-    @course = Course.create!(name: 'mycourse', source_backend: 'git', source_url: repo_path)
+    @organization = FactoryGirl.create(:accepted_organization, slug: 'slug')
+    @course = Course.create!(name: 'mycourse', source_backend: 'git', source_url: repo_path, organization: @organization)
     @repo = clone_course_repo(@course)
     @repo.copy_simple_exercise('MyExercise1')
     @repo.copy_simple_exercise('MyExercise2')
@@ -19,7 +20,7 @@ describe 'Personal deadlines', type: :request, integration: true do
 
     @user = FactoryGirl.create(:user, password: 'xooxer')
 
-    visit '/'
+    visit '/org/slug/courses'
     log_in_as(@user.login, @user.password)
     click_link 'mycourse'
   end
@@ -30,7 +31,7 @@ describe 'Personal deadlines', type: :request, integration: true do
 
     submit_correct_solution('MyExercise1')
 
-    visit '/'
+    visit '/org/slug/courses'
     click_link 'mycourse'
     expect(page).to have_content('MyExercise2')
     expect(page).not_to have_content('(locked)')
@@ -46,7 +47,7 @@ describe 'Personal deadlines', type: :request, integration: true do
 
       submit_correct_solution('MyExercise1')
 
-      visit '/'
+      visit '/org/slug/courses'
       click_link 'mycourse'
       expect(page).to have_content('MyExercise2 (locked)')
       expect(page).to have_content('unlock 1 new exercise')

--- a/spec/integration/requests/pastes_spec.rb
+++ b/spec/integration/requests/pastes_spec.rb
@@ -6,7 +6,8 @@ describe 'Paste JSON api', type: :request, integration: true do
   before :each do
     repo_path = Dir.pwd + '/remote_repo'
     create_bare_repo(repo_path)
-    @course = Course.create!(name: 'mycourse', source_backend: 'git', source_url: repo_path)
+    @organization = FactoryGirl.create(:accepted_organization, slug: 'slug')
+    @course = Course.create!(name: 'mycourse', source_backend: 'git', source_url: repo_path, organization: @organization)
     @repo = clone_course_repo(@course)
     @repo.copy_simple_exercise('MyExercise')
     @repo.add_commit_push
@@ -27,7 +28,7 @@ describe 'Paste JSON api', type: :request, integration: true do
   end
 
   def create_paste_submission(solve = false, user = nil, time = Time.now)
-    visit '/'
+    visit '/org/slug/courses'
     log_in_as(user.login, 'xooxer')
     click_link 'mycourse'
     ex = FixtureExercise::SimpleExercise.new('MyExercise')

--- a/spec/integration/stats_view_usecases_spec.rb
+++ b/spec/integration/stats_view_usecases_spec.rb
@@ -6,7 +6,8 @@ describe 'The system (used by an instructor for viewing statistics)', type: :req
   before :each do
     repo_path = Dir.pwd + '/remote_repo'
     create_bare_repo(repo_path)
-    course = Course.create!(name: 'mycourse', source_backend: 'git', source_url: repo_path)
+    organization = FactoryGirl.create(:accepted_organization, slug: 'slug')
+    course = Course.create!(name: 'mycourse', source_backend: 'git', source_url: repo_path, organization: organization)
     repo = clone_course_repo(course)
     repo.copy_simple_exercise('EasyExercise')
     repo.copy_simple_exercise('HardExercise')
@@ -36,7 +37,7 @@ describe 'The system (used by an instructor for viewing statistics)', type: :req
   end
 
   def visit_exercise(exercise_name)
-    visit '/'
+    visit '/org/slug/courses'
     click_link 'mycourse'
     first('.exercise-list').click_link exercise_name
   end
@@ -53,7 +54,7 @@ describe 'The system (used by an instructor for viewing statistics)', type: :req
     ex.introduce_compilation_error('oops') if options[:compilation_error]
     ex.make_zip
 
-    visit '/'
+    visit '/org/slug/courses'
     click_link 'mycourse'
     first('.exercise-list').click_link exercise_name
     attach_file('Zipped project', "#{exercise_name}.zip")

--- a/spec/integration/student_usecases_spec.rb
+++ b/spec/integration/student_usecases_spec.rb
@@ -7,7 +7,8 @@ describe 'The system (used by a student)', type: :request, integration: true do
   before :each do
     repo_path = Dir.pwd + '/remote_repo'
     create_bare_repo(repo_path)
-    @course = Course.create!(name: 'mycourse', source_backend: 'git', source_url: repo_path)
+    @organization = FactoryGirl.create(:accepted_organization, slug: 'slug')
+    @course = Course.create!(name: 'mycourse', source_backend: 'git', source_url: repo_path, organization: @organization)
     @repo = clone_course_repo(@course)
     @repo.copy_simple_exercise('MyExercise')
     @repo.add_commit_push
@@ -17,7 +18,7 @@ describe 'The system (used by a student)', type: :request, integration: true do
     @user = FactoryGirl.create(:user, password: 'xooxer')
     @ability = Ability.new(@user)
 
-    visit '/'
+    visit '/org/slug/courses'
     log_in_as(@user.login, 'xooxer')
     click_link 'mycourse'
   end
@@ -81,7 +82,7 @@ describe 'The system (used by a student)', type: :request, integration: true do
     @repo.add_commit_push
     @course.refresh
 
-    visit '/'
+    visit '/org/slug/courses'
     click_link 'mycourse'
 
     expect(page).not_to have_content('MyExercise')
@@ -92,7 +93,7 @@ describe 'The system (used by a student)', type: :request, integration: true do
     @repo.add_commit_push
     @course.refresh
 
-    visit '/'
+    visit '/org/slug/courses'
     click_link 'mycourse'
 
     expect(page).to have_content('MyExercise')
@@ -149,7 +150,7 @@ describe 'The system (used by a student)', type: :request, integration: true do
     click_button 'Submit'
     wait_for_submission_to_be_processed
 
-    visit '/'
+    visit '/org/slug/courses'
     click_link 'mycourse'
     first('.exercise-list').click_link 'MyExercise'
     click_link 'View suggested solution'
@@ -167,7 +168,7 @@ describe 'The system (used by a student)', type: :request, integration: true do
     click_button 'Submit'
     wait_for_submission_to_be_processed
 
-    visit '/'
+    visit '/org/slug/courses'
     click_link 'mycourse'
     first('.exercise-list').click_link 'MyExercise'
 
@@ -177,7 +178,7 @@ describe 'The system (used by a student)', type: :request, integration: true do
   it 'should not count submissions made by non legitimate_students in submission counts' do
     @fake_user = FactoryGirl.create(:admin, login: 'uuseri', password: 'xooxer', legitimate_student: false)
     log_out
-    visit '/'
+    visit '/org/slug/courses'
     log_in_as(@fake_user.login, 'xooxer')
 
     FixtureExercise::SimpleExercise.new('MyExercise')
@@ -210,7 +211,7 @@ describe 'The system (used by a student)', type: :request, integration: true do
     expect(page).to have_content('Goodbye')
     @other_user = FactoryGirl.create(:user, login: 'uuseri', password: 'xooxer')
 
-    visit '/'
+    visit '/org/slug/courses'
     log_in_as(@other_user.login, 'xooxer')
 
     @ability = Ability.new(@other_user)
@@ -315,7 +316,7 @@ describe 'The system (used by a student)', type: :request, integration: true do
       expect(page).to have_content('All tests successful')
       expect(page).to have_content('Ok')
 
-      visit '/'
+      visit '/org/slug/courses'
 
       log_out
 
@@ -378,7 +379,7 @@ describe 'The system (used by a student)', type: :request, integration: true do
       expect(page).to have_content('All tests successful')
       expect(page).to have_content('Ok')
 
-      visit '/'
+      visit '/org/slug/courses'
 
       log_out
 

--- a/spec/integration/utf8_exercise_spec.rb
+++ b/spec/integration/utf8_exercise_spec.rb
@@ -7,7 +7,8 @@ describe 'The system, receiving submissions with UTF-8 special characters', type
   before :each do
     repo_path = Dir.pwd + '/remote_repo'
     create_bare_repo(repo_path)
-    @course = Course.create!(name: 'mycourse', source_backend: 'git', source_url: repo_path)
+    @organization = FactoryGirl.create(:accepted_organization, slug: 'slug')
+    @course = Course.create!(name: 'mycourse', source_backend: 'git', source_url: repo_path, organization: @organization)
     @repo = clone_course_repo(@course)
     @repo.copy(FixtureExercise.fixture_exercises_root + '/Utf8')
     @repo.add_commit_push
@@ -16,7 +17,7 @@ describe 'The system, receiving submissions with UTF-8 special characters', type
 
     @user = FactoryGirl.create(:user, password: 'xooxer')
 
-    visit '/'
+    visit '/org/slug/courses'
     log_in_as(@user.login, 'xooxer')
     click_link 'mycourse'
 

--- a/spec/support/integration_test_actions.rb
+++ b/spec/support/integration_test_actions.rb
@@ -18,7 +18,8 @@ module IntegrationTestActions
   end
 
   def create_new_course(options = {})
-    visit '/courses'
+    visit "/org/#{options[:organization_slug]}/courses"
+    #save_and_open_page
     click_link 'Create New Course'
     fill_in 'course_name', with: options[:name]
     # fill_in 'course_source_backend', :with => options[:source_backend] if options[:source_backend]
@@ -29,8 +30,8 @@ module IntegrationTestActions
     expect(page).to have_content(options[:name])
   end
 
-  def manually_refresh_course(coursename)
-    visit '/courses'
+  def manually_refresh_course(coursename, organization_slug)
+    visit "/org/#{organization_slug}/courses"
     click_link coursename
     click_on 'Refresh'
     expect(page).to have_content('Refresh successful.')

--- a/spec/support/submission_test_setup.rb
+++ b/spec/support/submission_test_setup.rb
@@ -14,7 +14,7 @@ class SubmissionTestSetup
   def initialize(options = {})
     options = default_options.merge(options)
 
-    organization_id = options[:organization].id || 1
+    organization = options[:organization] || Organization.create!(name: 'name', information: 'info', slug: 'slug', acceptance_pending: false)
     course_name = options[:course_name]
     exercise_name = options[:exercise_name] || 'SimpleExercise'
     exercise_dest = options[:exercise_dest] || exercise_name
@@ -25,7 +25,7 @@ class SubmissionTestSetup
     @repo_path = 'remote_repo'
     create_bare_repo(@repo_path)
 
-    @course = Course.create!(name: course_name, source_backend: 'git', source_url: @repo_path, organization_id: organization_id)
+    @course = Course.create!(name: course_name, source_backend: 'git', source_url: @repo_path, organization: organization)
     @repo = clone_course_repo(@course)
     @repo.copy_fixture_exercise(exercise_name, exercise_dest)
     @repo.add_commit_push

--- a/spec/support/submission_test_setup.rb
+++ b/spec/support/submission_test_setup.rb
@@ -14,6 +14,7 @@ class SubmissionTestSetup
   def initialize(options = {})
     options = default_options.merge(options)
 
+    organization_id = options[:organization].id || 1
     course_name = options[:course_name]
     exercise_name = options[:exercise_name] || 'SimpleExercise'
     exercise_dest = options[:exercise_dest] || exercise_name
@@ -24,7 +25,7 @@ class SubmissionTestSetup
     @repo_path = 'remote_repo'
     create_bare_repo(@repo_path)
 
-    @course = Course.create!(name: course_name, source_backend: 'git', source_url: @repo_path)
+    @course = Course.create!(name: course_name, source_backend: 'git', source_url: @repo_path, organization_id: organization_id)
     @repo = clone_course_repo(@course)
     @repo.copy_fixture_exercise(exercise_name, exercise_dest)
     @repo.add_commit_push


### PR DESCRIPTION
Because courses belong to organizations now, all course paths were reconfigured to include organization id (slug).