### PR TITLE
User sees own organizations on front page

### DIFF
--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -126,6 +126,7 @@ span.git-branch {
   padding-left: 10pt;
 }
 
+tr.hidden-organization *,
 tr.hidden-course * {
   color: gray;
   font-color: gray;

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -96,7 +96,7 @@ class OrganizationsController < ApplicationController
     authorize! :toggle_visibility, @organization
     @organization.hidden = !@organization.hidden
     @organization.save!
-    redirect_to organization_path, notice: "Organzation is now #{@organization.hidden ? 'hidden to users':'visible to users'}"
+    redirect_to organization_path, notice: "Organization is now #{@organization.hidden ? 'hidden to users':'visible to users'}"
   end
 
   private

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -6,9 +6,8 @@ class OrganizationsController < ApplicationController
   skip_authorization_check only: [:index]
 
   def index
-    ordering = 'LOWER(name)'
+    ordering = 'hidden, LOWER(name)'
     @organizations = Organization.accepted_organizations.order(ordering)
-
     @my_organizations = Organization.taught_organizations(current_user)
     @my_organizations |= Organization.assisted_organizations(current_user)
     @my_organizations |= Organization.participated_organizations(current_user)

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,3 +1,5 @@
+require 'natsort'
+
 class OrganizationsController < ApplicationController
   before_action :set_organization, only: [:show, :edit, :update, :destroy, :accept, :reject, :reject_reason_input, :toggle_visibility]
 
@@ -6,6 +8,11 @@ class OrganizationsController < ApplicationController
   def index
     ordering = 'LOWER(name)'
     @organizations = Organization.accepted_organizations.order(ordering)
+
+    @my_organizations = Organization.taught_organizations(current_user)
+    @my_organizations |= Organization.assisted_organizations(current_user)
+    @my_organizations |= Organization.participated_organizations(current_user)
+    @my_organizations.natsort_by!(&:name)
   end
 
   def show

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -23,6 +23,9 @@ class Organization < ActiveRecord::Base
 
   scope :accepted_organizations, -> { where(acceptance_pending: false).where(rejected: false) }
   scope :pending_organizations, -> { where(acceptance_pending: true) }
+  scope :assisted_organizations, ->(user) { joins(:courses, courses: :assistantships).where(assistantships: { user_id: user.id }) }
+  scope :taught_organizations, ->(user) { joins(:teacherships).where(teacherships: { user_id: user.id }) }
+  scope :participated_organizations, ->(user) { joins(:courses, courses: :awarded_points).where(awarded_points: { user_id: user.id }) }
 
   def self.init(params, initial_user)
     organization = Organization.new(params.merge(acceptance_pending: true))

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -181,6 +181,11 @@ class User < ActiveRecord::Base
     Assistantship.find_by(user_id: self, course_id: course)
   end
 
+  # Checks if the user is only a student. Returns false if the user is a student and also an assistant in any course
+  def student?
+    !guest? && !administrator? && !Teachership.exists?(user_id: self.id) && !Assistantship.exists?(user_id: self.id)
+  end
+
   private
 
   def encrypt_password

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -181,11 +181,6 @@ class User < ActiveRecord::Base
     Assistantship.find_by(user_id: self, course_id: course)
   end
 
-  # Checks if the user is only a student. Returns false if the user is a student and also an assistant in any course
-  def student?
-    !guest? && !administrator? && !Teachership.exists?(user_id: self.id) && !Assistantship.exists?(user_id: self.id)
-  end
-
   private
 
   def encrypt_password

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -39,22 +39,21 @@
     <th>Information</th>
     <% if current_user.administrator? %>
       <th></th>
-      <th></th>
     <% end %>
   </tr>
   </thead>
 
   <tbody>
   <% @organizations.each do |organization| %>
-    <tr>
-      <td><%= link_to organization.name, organization_path(organization) %></td>
-      <td><%= organization.information %></td>
-
-      <% if current_user.administrator? %>
-        <td><%= link_to 'Edit', edit_organization_path(organization) %></td>
-        <td><%= link_to 'Destroy', organization, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-      <% end %>
-    </tr>
+    <% if !organization.hidden? || current_user.administrator? %>
+      <tr class="<%= "hidden-organization" if organization.hidden?  %>">
+        <td><%= link_to organization.name, organization_path(organization) %></td>
+        <td><%= organization.information %></td>
+        <% if current_user.administrator? %>
+          <td><%= link_to 'Edit', edit_organization_path(organization) %></td>
+        <% end %>
+      </tr>
+    <% end %>
   <% end %>
   </tbody>
 </table>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -45,8 +45,8 @@
 
   <tbody>
   <% @organizations.each do |organization| %>
-    <% if !organization.hidden? || current_user.administrator? %>
-      <tr class="<%= "hidden-organization" if organization.hidden?  %>">
+    <% if !organization.hidden? || can?(:view_hidden_organizations, nil) %>
+      <tr class="<%= 'hidden-organization' if organization.hidden?  %>">
         <td><%= link_to organization.name, organization_path(organization) %></td>
         <td><%= organization.information %></td>
         <% if current_user.administrator? %>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,7 +1,5 @@
 <h1>Welcome to TMC</h1>
 
-<h2>Organizations</h2>
-
 <% if current_user.administrator? && !Organization.pending_organizations.empty? %>
   <div class="alert alert-warning" role="alert">
     <%= pluralize(Organization.pending_organizations.size, 'new organization request') %>.
@@ -9,7 +7,32 @@
   </div>
 <% end %>
 
-<table id="organization-table">
+<% unless @my_organizations.empty? %>
+  <h2>My organizations</h2>
+
+  <table id="my-organizations-table" class="table">
+    <thead>
+    <tr>
+      <th>Name</th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @my_organizations.each do |organization| %>
+      <tr>
+        <td><%= link_to organization.name, organization_path(organization) %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<% if @my_organizations.empty? %>
+  <h2>Organizations</h2>
+<% else %>
+  <h2>All organizations</h2>
+<% end %>
+
+<table id="organization-table" class="table">
   <thead>
   <tr>
     <th>Name</th>

--- a/spec/features/teacher_creates_organization_spec.rb
+++ b/spec/features/teacher_creates_organization_spec.rb
@@ -55,8 +55,7 @@ feature 'User can create new organization', feature: true do
     @organization = FactoryGirl.create :accepted_organization
     Teachership.create!(user: @user, organization: @organization)
     log_in_as(@user.login, 'foobar2')
-    click_link @organization.name
-    expect(page).to have_content @organization.name
+    visit "/org/#{@organization.slug}"
     click_link 'hide organization'
     expect(page).to have_content "Organzation is now hidden to users"
     expect(page).to have_content 'make organization visible'

--- a/spec/features/teacher_creates_organization_spec.rb
+++ b/spec/features/teacher_creates_organization_spec.rb
@@ -57,7 +57,7 @@ feature 'User can create new organization', feature: true do
     log_in_as(@user.login, 'foobar2')
     visit "/org/#{@organization.slug}"
     click_link 'hide organization'
-    expect(page).to have_content "Organzation is now hidden to users"
+    expect(page).to have_content "Organization is now hidden to users"
     expect(page).to have_content 'make organization visible'
   end
 end

--- a/spec/features/user_views_organization_list_spec.rb
+++ b/spec/features/user_views_organization_list_spec.rb
@@ -92,4 +92,12 @@ feature 'User views organization list', feature: true do
       expect(page).to_not have_content('Organization Five')
     end
   end
+
+  scenario 'Hidden organization is not visible to user in organization list' do
+    @organization = FactoryGirl.create :accepted_organization
+    @organization.hidden = true
+    @organization.save!
+    log_in_as(@user.login, 'foobar')
+    expect(page).to_not have_link @organization.name
+  end
 end

--- a/spec/features/user_views_organization_list_spec.rb
+++ b/spec/features/user_views_organization_list_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+feature 'User views organization list', feature: true do
+  include IntegrationTestActions
+
+  before :each do
+    @organization1 = FactoryGirl.create :accepted_organization, name: 'Organization One'
+    @organization2 = FactoryGirl.create :accepted_organization, name: 'Organization Two'
+    @organization3 = FactoryGirl.create :accepted_organization, name: 'Organization Three'
+    @organization4 = FactoryGirl.create :accepted_organization, name: 'Organization Four'
+    @organization5 = FactoryGirl.create :accepted_organization, name: 'Organization Five'
+
+    @course1 = FactoryGirl.create :course, name: 'org1course1', organization: @organization1
+    @course2 = FactoryGirl.create :course, name: 'org3course1', organization: @organization3
+    @course3 = FactoryGirl.create :course, name: 'org4course1', organization: @organization4
+    @course4 = FactoryGirl.create :course, name: 'org4course2', organization: @organization4
+
+    @user = FactoryGirl.create :user, password: 'foobar'
+    @teacher = FactoryGirl.create :user, password: 'foobar'
+    @assistant = FactoryGirl.create :user, password: 'foobar'
+
+    Teachership.create! user: @teacher, organization: @organization1
+    Teachership.create! user: @teacher, organization: @organization2
+
+    Assistantship.create! user: @assistant, course: @course1
+    Assistantship.create! user: @assistant, course: @course2
+
+    FactoryGirl.create :awarded_point, course: @course1, user: @user
+    FactoryGirl.create :awarded_point, course: @course3, user: @user
+    FactoryGirl.create :awarded_point, course: @course4, user: @user
+
+    visit '/'
+  end
+
+  scenario 'Guest does not see the My organization list' do
+    expect(page).to_not have_content('My organizations')
+  end
+
+  scenario 'Student can see the organizations in which they have awarded points' do
+    log_in_as(@user.login, 'foobar')
+    expect(page).to have_content('My organizations')
+
+    within('table#my-organizations-table') do
+      expect(page).to have_content('Organization Four')
+      expect(page).to have_content('Organization One')
+      expect(page).to_not have_content('Organization Two')
+      expect(page).to_not have_content('Organization Three')
+      expect(page).to_not have_content('Organization Five')
+    end
+  end
+
+  scenario 'Assistant can see the organizations in which they are an assistant in some course(s)' do
+    log_in_as(@assistant.login, 'foobar')
+    expect(page).to have_content('My organizations')
+
+    within('table#my-organizations-table') do
+      expect(page).to have_content('Organization One')
+      expect(page).to have_content('Organization Three')
+      expect(page).to_not have_content('Organization Two')
+      expect(page).to_not have_content('Organization Four')
+      expect(page).to_not have_content('Organization Five')
+    end
+  end
+
+  scenario 'Teacher can see the organizations they teach' do
+    log_in_as(@teacher.login, 'foobar')
+    expect(page).to have_content('My organizations')
+
+    within('table#my-organizations-table') do
+      expect(page).to have_content('Organization One')
+      expect(page).to have_content('Organization Two')
+      expect(page).to_not have_content('Organization Three')
+      expect(page).to_not have_content('Organization Four')
+      expect(page).to_not have_content('Organization Five')
+    end
+  end
+
+  scenario 'User with multiple own organizations with different conditions sees them all' do
+    user = FactoryGirl.create :user, password: 'foobar'
+    Teachership.create! user: user, organization: @organization1
+    Assistantship.create! user: user, course: @course2
+    FactoryGirl.create :awarded_point, course: @course3, user: user
+
+    log_in_as(user.login, 'foobar')
+    expect(page).to have_content('My organization')
+
+    within('table#my-organizations-table') do
+      expect(page).to have_content('Organization One')
+      expect(page).to have_content('Organization Three')
+      expect(page).to have_content('Organization Four')
+      expect(page).to_not have_content('Organization Two')
+      expect(page).to_not have_content('Organization Five')
+    end
+  end
+end


### PR DESCRIPTION
All user types (students/assistants/teachers) should see now their own relevant organizations listed first separately.

Might be that whole test suite isn't run for this at this moment, but relevant tests passed.