### PR TITLE
Submission result visibility

### DIFF
--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -10,6 +10,10 @@
   color: green;
 }
 
+.h_i_d_d_e_n {  /* Submision status :hidden is change for css to be 'h_i_d_d_e_n' so that we can see it (: */
+    color: orange;
+}
+
 /* Basic commons */
 
 .small{

--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -10,8 +10,8 @@
   color: green;
 }
 
-.h_i_d_d_e_n {  /* Submision status :hidden is change for css to be 'h_i_d_d_e_n' so that we can see it (: */
-    color: orange;
+.hidden_status {
+  color: orange;
 }
 
 /* Basic commons */

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -200,9 +200,8 @@ class CoursesController < ApplicationController
 
   def toggle_submission_result_visibility
     authorize! :toggle_submission_result_visibility, @course
-    @course.hide_submission_result = !@course.hide_submission_result
-    @course.save!
-    redirect_to organization_course_path(@organization, @course), notice: "Submission results are now #{@course.hide_submission_result ? 'hidden' : 'visible'}"
+    @course.toggle_submission_result_visiblity
+    redirect_to organization_course_path(@organization, @course), notice: "Submission results are now #{@course.hide_submission_results ? 'hidden' : 'visible'}"
   end
 
   private

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -198,6 +198,13 @@ class CoursesController < ApplicationController
     @exercises_id_map = @exercises.map { |e| [e.id, e] }.to_h
   end
 
+  def toggle_submission_result_visibility
+    authorize! :toggle_submission_result_visibility, @course
+    @course.hide_submission_result = !@course.hide_submission_result
+    @course.save!
+    redirect_to organization_course_path(@organization, @course), notice: "Submission results are now #{@course.hide_submission_result ? 'hidden' : 'visible'}"
+  end
+
   private
 
   def course_params_for_create

--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -8,7 +8,7 @@ class PointsController < ApplicationController
     @course = Course.find(params[:course_id])
     authorize! :see_points, @course
     add_course_breadcrumb
-    add_breadcrumb 'Points', organization_course_points_path(@organization, @course)
+    add_breadcrumb 'Points'
 
     exercises = @course.exercises.select { |e| e.points_visible_to?(current_user) }
     sheets = @course.gdocs_sheets(exercises).natsort

--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -2,11 +2,11 @@ require 'natsort'
 # Shows the points summary table and exercise group-specific tables.
 class PointsController < ApplicationController
   include PointsHelper
-  skip_authorization_check except: :refresh_gdocs
   before_action :set_organization
 
   def index
     @course = Course.find(params[:course_id])
+    authorize! :see_points, @course
     add_course_breadcrumb
     add_breadcrumb 'Points', organization_course_points_path(@organization, @course)
 
@@ -34,6 +34,7 @@ class PointsController < ApplicationController
   def show
     @sheetname = params[:id]
     @course = Course.find(params[:course_id])
+    authorize! :see_points, @course
 
     add_course_breadcrumb
     add_breadcrumb 'Points', organization_course_points_path(@organization, @course)
@@ -61,6 +62,8 @@ class PointsController < ApplicationController
       end
     end
   end
+
+  private
 
   def summary_hash(course, visible_exercises, sheets)
     per_user_and_sheet = {}
@@ -105,8 +108,6 @@ class PointsController < ApplicationController
       summary[:users] = summary[:users].sort_by { |user| [-summary[:awarded_for_user_and_sheet][user.login][sheet].to_i, user.login] }
     end
   end
-
-  private
 
   def set_organization
     @organization = Organization.find_by(slug: params[:organization_id])

--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -38,7 +38,7 @@ class PointsController < ApplicationController
 
     add_course_breadcrumb
     add_breadcrumb 'Points', organization_course_points_path(@organization, @course)
-    add_breadcrumb @sheetname, organization_course_point_path(@organization, @course, @sheetname)
+    add_breadcrumb @sheetname
 
     @exercises = Exercise.course_gdocs_sheet_exercises(@course, @sheetname).order!
     @users_to_points = AwardedPoint.per_user_in_course_with_sheet(@course, @sheetname)

--- a/app/controllers/solutions_controller.rb
+++ b/app/controllers/solutions_controller.rb
@@ -7,7 +7,7 @@ class SolutionsController < ApplicationController
 
     add_course_breadcrumb
     add_exercise_breadcrumb
-    add_breadcrumb 'Suggested solution', exercise_solution_path(@exercise)
+    add_breadcrumb 'Suggested solution'
 
     @solution = @exercise.solution
     begin

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -45,14 +45,14 @@ class SubmissionsController < ApplicationController
           user_id: @submission.user_id,
           course: @course.name,
           exercise_name: @submission.exercise.name,
-          status: @submission.status,
+          status: @submission.status(current_user),
           points: @submission.points_list,
           processing_time: @submission.processing_time,
           message_for_paste: @submission.message_for_paste,
           missing_review_points: @exercise.missing_review_points_for(@submission.user)
         }
         output = output.merge(
-          case @submission.status
+          case @submission.status(current_user)
           when :processing then {
             submissions_before_this: @submission.unprocessed_submissions_before_this,
             total_unprocessed: Submission.unprocessed_count
@@ -66,6 +66,10 @@ class SubmissionsController < ApplicationController
             feedback_questions: @course.feedback_questions.order(:position).map(&:record_for_api),
             feedback_answer_url: submission_feedback_answers_url(@submission, format: :json),
             processing_time: @submission.processing_time
+          }
+          when :hidden then {
+            points: 0,
+            test_cases: nil
           }
           end
         )

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -3,7 +3,7 @@ require 'submission_processor'
 # Receives submissions and presents the full submission list and submission view.
 # Also handles rerun requests.
 class SubmissionsController < ApplicationController
-  around_action :course_transaction # is this really needed to do all methods. should have except: [:index, :show] ?
+  around_action :course_transaction
   before_action :get_course_and_exercise
 
   # Manually checked for #show and index

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -3,7 +3,7 @@ require 'submission_processor'
 # Receives submissions and presents the full submission list and submission view.
 # Also handles rerun requests.
 class SubmissionsController < ApplicationController
-  around_action :course_transaction
+  around_action :course_transaction # is this really needed to do all methods. should have except: [:index, :show] ?
   before_action :get_course_and_exercise
 
   # Manually checked for #show and index
@@ -19,8 +19,9 @@ class SubmissionsController < ApplicationController
         end
       end
       format.html do # uses AJAX
+        @organization = @course.organization
         add_course_breadcrumb
-        add_breadcrumb 'All submissions', course_submissions_path(@course)
+        add_breadcrumb 'All submissions'
       end
     end
   end

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -16,8 +16,9 @@ module SubmissionsHelper
   end
 
   def submission_status(submission)
-    status = submission.status
-    raw("<span class=\"#{status}\">#{status.to_s.capitalize}</span>")
+    status = submission.status(current_user)
+    # if status is :hidden we have to give something else to css so that we can see it
+    raw("<span class=\"#{status == :hidden ? 'h_i_d_d_e_n' : status}\">#{status.to_s.capitalize}</span>")
   end
 
   def submission_review_column(submission)

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -17,8 +17,7 @@ module SubmissionsHelper
 
   def submission_status(submission)
     status = submission.status(current_user)
-    # if status is :hidden we have to give something else to css so that we can see it
-    raw("<span class=\"#{status == :hidden ? 'h_i_d_d_e_n' : status}\">#{status.to_s.capitalize}</span>")
+    raw("<span class=\"#{status == :hidden ? 'hidden_status' : status}\">#{status.to_s.capitalize}</span>")
   end
 
   def submission_review_column(submission)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -64,7 +64,7 @@ class Ability
         !sub.course.hide_submission_result? && can?(:read, sub)
       end
 
-      can :see_result, Submission do |sub|
+      can :read_result, Submission do |sub|
         !sub.course.hide_submission_result? || can?(:teach, sub.course)
       end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -173,6 +173,10 @@ class Ability
         can? :teach, c.organization
       end
 
+      can :toggle_submission_result_visibility, Course do |c|
+        can? :teach, c
+      end
+
       cannot :teach, Organization
       can :teach, Organization do |o|
         o.teacher?(user) && !o.rejected? && !o.acceptance_pending?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -100,8 +100,7 @@ class Ability
       cannot :read, Solution
       can :read, Solution do |sol|
         course = sol.exercise.course
-        (sol.visible_to?(user) && course.hide_submission_result?) ||
-            (can? :teach, course)
+        sol.visible_to?(user) || (can? :teach, course)
       end
 
       cannot :manage, Review

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -177,6 +177,10 @@ class Ability
         can? :teach, c
       end
 
+      can :see_points, Submission do |s|
+        !s.course.hide_submission_result? || can?(:teach, s.course)
+      end
+
       cannot :teach, Organization
       can :teach, Organization do |o|
         o.teacher?(user) && !o.rejected? && !o.acceptance_pending?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -60,12 +60,8 @@ class Ability
         can? :teach, sub.course
       end
 
-      can :download, Submission do |sub|
-        !sub.course.hide_submission_result? && can?(:read, sub)
-      end
-
-      can :read_result, Submission do |sub|
-        !sub.course.hide_submission_result? || can?(:teach, sub.course)
+      can :read_results, Submission do |sub|
+        !sub.course.hide_submission_results? || (can? :teach, sub.course)
       end
 
       cannot :manage_feedback_questions, Course
@@ -187,7 +183,7 @@ class Ability
       end
 
       can :see_points, Course do |c|
-        !c.hide_submission_result? || can?(:teach, c)
+        !c.hide_submission_results? || (can? :teach, c)
       end
 
       cannot :teach, Organization

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -60,6 +60,14 @@ class Ability
         can? :teach, sub.course
       end
 
+      can :download, Submission do |sub|
+        !sub.course.hide_submission_result? && can?(:read, sub)
+      end
+
+      can :see_result, Submission do |sub|
+        !sub.course.hide_submission_result? || can?(:teach, sub.course)
+      end
+
       cannot :manage_feedback_questions, Course
       can :manage_feedback_questions, Course do |c|
         can? :teach, c
@@ -91,7 +99,9 @@ class Ability
 
       cannot :read, Solution
       can :read, Solution do |sol|
-        sol.visible_to?(user) || (can? :teach, sol.exercise.course)
+        course = sol.exercise.course
+        (sol.visible_to?(user) && course.hide_submission_result?) ||
+            (can? :teach, course)
       end
 
       cannot :manage, Review
@@ -177,8 +187,8 @@ class Ability
         can? :teach, c
       end
 
-      can :see_points, Submission do |s|
-        !s.course.hide_submission_result? || can?(:teach, s.course)
+      can :see_points, Course do |c|
+        !c.hide_submission_result? || can?(:teach, c)
       end
 
       cannot :teach, Organization

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -250,6 +250,11 @@ class Course < ActiveRecord::Base
     submissions.where('(requests_review OR requires_review) AND NOT reviewed AND NOT newer_submission_reviewed AND NOT review_dismissed')
   end
 
+  def toggle_submission_result_visiblity
+    self.hide_submission_results = !self.hide_submission_results
+    save!
+  end
+
   # Returns a hash of exercise group => {
   #   :available_points => number of available points,
   #   :points_by_user => {user_id => number_of_points}

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -23,7 +23,7 @@ class Solution
       false
     elsif @exercise.submittable_by?(user) && !@exercise.completed_by?(user)
       false
-    elsif @exercise.course.hide_submission_result?
+    elsif @exercise.course.hide_submission_results?
       false
     else
       show_when_completed = SiteSetting.value('show_model_solutions_when_exercise_completed')

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -23,6 +23,8 @@ class Solution
       false
     elsif @exercise.submittable_by?(user) && !@exercise.completed_by?(user)
       false
+    elsif @exercise.course.hide_submission_result?
+      false
     else
       show_when_completed = SiteSetting.value('show_model_solutions_when_exercise_completed')
       show_when_expired = SiteSetting.value('show_model_solutions_when_exercise_expired')

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -98,9 +98,11 @@ class Submission < ActiveRecord::Base
     k =~ /^[a-zA-Z\-_]+$/ && v =~ /^[a-zA-Z\-_]+$/
   end
 
-  def status
+  def status(user)
     if !processed?
       :processing
+    elsif cannot_see_results?(user)
+      :hidden
     elsif all_tests_passed?
       :ok
     elsif tests_ran?
@@ -108,6 +110,12 @@ class Submission < ActiveRecord::Base
     else
       :error
     end
+  end
+
+  def cannot_see_results?(user)
+    (all_tests_passed? || tests_ran?) &&
+        !(user.administrator? || self.course.organization.teacher?(user) || self.course.assistant?(user)) &&
+        self.course.hide_submission_result
   end
 
   def points_list

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -101,7 +101,7 @@ class Submission < ActiveRecord::Base
   def status(user)
     if !processed?
       :processing
-    elsif cannot_see_results?(user)
+    elsif !can_see_results?(user)
       :hidden
     elsif all_tests_passed?
       :ok
@@ -112,10 +112,11 @@ class Submission < ActiveRecord::Base
     end
   end
 
-  def cannot_see_results?(user)
-    (all_tests_passed? || tests_ran?) &&
-        !(user.administrator? || self.course.organization.teacher?(user) || self.course.assistant?(user)) &&
-        self.course.hide_submission_result
+  def can_see_results?(user)
+    !(self.course.hide_submission_results? && (all_tests_passed? || tests_ran?)) ||
+        self.course.organization.teacher?(user) ||
+        self.course.assistant?(user) ||
+        user.administrator?
   end
 
   def points_list

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -11,7 +11,7 @@
       <% end %>
 
       <ul>
-        <% if can? :see_submission_results, @course %>
+        <% if can? :see_points, @course %>
           <li><%= link_to 'View points', organization_course_points_path(@organization, @course) %></li>
         <% end %>
         <% if can? :view_code_reviews, @course %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -6,7 +6,7 @@
       <p><%= link_to 'Material', @course.material_url %></p>
     <% end %>
     <div>
-      <% if @refresh_report && can?(:refresh, @course) %>
+      <% if @refresh_report && (can? :refresh, @course) %>
         <%= render :partial => 'courses/refresh_report', :locals => { :report => @refresh_report } %>
       <% end %>
 
@@ -116,7 +116,7 @@
         <%= link_to 'Manage assistants', organization_course_assistants_path(@organization, @course), class: "btn btn-default btn-mini" %>
       <% end %>
       <% if can? :toggle_submission_result_visibility, @course %>
-        <% if @course.hide_submission_result? %>
+        <% if @course.hide_submission_results? %>
           <%= link_to 'Unhide submission results', toggle_submission_result_visibility_organization_course_path(@organization, @course), method: :post, class: "btn btn-primary btn-mini" %>
         <% else %>
           <%= link_to 'Hide submission results', toggle_submission_result_visibility_organization_course_path(@organization, @course), method: :post, class: "btn btn-warning btn-mini" %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -117,9 +117,9 @@
       <% end %>
       <% if can? :toggle_submission_result_visibility, @course %>
         <% if @course.hide_submission_result? %>
-          <%= link_to 'Unhide submssion results', toggle_submission_result_visibility_organization_course_path(@organization, @course), method: :post, class: "btn btn-primary btn-mini" %>
+          <%= link_to 'Unhide submission results', toggle_submission_result_visibility_organization_course_path(@organization, @course), method: :post, class: "btn btn-primary btn-mini" %>
         <% else %>
-          <%= link_to 'Hide submssion results', toggle_submission_result_visibility_organization_course_path(@organization, @course), method: :post, class: "btn btn-warning btn-mini" %>
+          <%= link_to 'Hide submission results', toggle_submission_result_visibility_organization_course_path(@organization, @course), method: :post, class: "btn btn-warning btn-mini" %>
         <% end %>
       <% end %>
       <% if can? :refresh, @course %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -113,6 +113,13 @@
       <% if can? :teach, @organization %>
         <%= link_to 'Manage assistants', organization_course_assistants_path(@organization, @course), class: "btn btn-default btn-mini" %>
       <% end %>
+      <% if can? :toggle_submission_result_visibility, @course %>
+        <% if @course.hide_submission_result? %>
+          <%= link_to 'Unhide submssion results', toggle_submission_result_visibility_organization_course_path(@organization, @course), method: :post, class: "btn btn-primary btn-mini" %>
+        <% else %>
+          <%= link_to 'Hide submssion results', toggle_submission_result_visibility_organization_course_path(@organization, @course), method: :post, class: "btn btn-warning btn-mini" %>
+        <% end %>
+      <% end %>
       <% if can? :refresh, @course %>
         <%= link_to 'Refresh', refresh_organization_course_path(@organization, @course), class: "btn btn-warning btn-mini" %>
       <% end %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -11,7 +11,9 @@
       <% end %>
 
       <ul>
-        <li><%= link_to 'View points', organization_course_points_path(@organization, @course) %></li>
+        <% if can? :see_submission_results, @course %>
+          <li><%= link_to 'View points', organization_course_points_path(@organization, @course) %></li>
+        <% end %>
         <% if can? :view_code_reviews, @course %>
           <li><%= link_to 'View code reviews', organization_course_reviews_path(@organization, @course) %></li>
         <% end %>

--- a/app/views/exercises/show.html.erb
+++ b/app/views/exercises/show.html.erb
@@ -55,7 +55,7 @@
     <li><%= link_to 'View suggested solution', exercise_solution_path(@exercise) %></li>
   <% end %>
 
-  <% if can?(:read, FeedbackAnswer) %>
+  <% if can? :read, FeedbackAnswer %>
     <li><%= link_to 'View feedback', exercise_feedback_answers_path(@exercise) %></li>
   <% end %>
 </ul>

--- a/app/views/participants/show.html.erb
+++ b/app/views/participants/show.html.erb
@@ -15,11 +15,15 @@
   <h2>Points</h2>
   <% for course in @courses %>
     <h3><%= course.name %></h3>
-    <ul>
-      <li>Completed: <%= sprintf("%.0f", @percent_completed[course.id]) %>%</li>
-      <li>Awarded points: <%= points_list(@awarded_points[course.id]) %></li>
-      <li>Missing points: <%= points_list(@missing_points[course.id]) %></li>
-    </ul>
+    <% if can? :see_points, course %>
+      <ul>
+        <li>Completed: <%= sprintf("%.0f", @percent_completed[course.id]) %>%</li>
+        <li>Awarded points: <%= points_list(@awarded_points[course.id]) %></li>
+        <li>Missing points: <%= points_list(@missing_points[course.id]) %></li>
+      </ul>
+    <% else %>
+      For this course points are not visible.
+    <% end %>
   <% end %>
 </section>
 

--- a/app/views/points/show.html.erb
+++ b/app/views/points/show.html.erb
@@ -5,9 +5,6 @@
 
 <ul>
   <li>
-    <%= link_to 'Back to summary', organization_course_points_path(@organization, @course) %>
-  </li>
-  <li>
     <% if params[:sort_by].blank? %>
       <%= link_to 'Sort by points', organization_course_point_path(@organization, @course, @sheetname, :sort_by => 'points') %>
     <% else %>

--- a/app/views/submissions/_details.html.erb
+++ b/app/views/submissions/_details.html.erb
@@ -35,7 +35,7 @@
             <tr>
               <th>Case</th>
               <th>Status</th>
-              <% if !@submission.all_tests_passed? %>
+              <% if !@submission.all_tests_passed? && can?(:see_result, @submission) %>
                 <th>Info</th>
               <% end %>
             </tr>
@@ -46,13 +46,15 @@
               <tr>
                 <td><%= tcr.test_case_name %></td>
                 <td>
-                  <% if tcr.successful? %>
+                  <% if cannot?(:see_result, @submission) %>
+                      <span class="h_i_d_d_e_n">Hidden</span>
+                  <% elsif tcr.successful? %>
                     <span class="success">Ok</span>
                   <% else %>
                     <span class="failure">Fail</span>
                   <% end %>
                 </td>
-                <% if !@submission.all_tests_passed? %>
+                <% if !@submission.all_tests_passed? && can?(:see_result, @submission) %>
                   <td>
                     <%= tcr.message %>
                     <% if tcr.exception != nil %>

--- a/app/views/submissions/_details.html.erb
+++ b/app/views/submissions/_details.html.erb
@@ -35,7 +35,7 @@
             <tr>
               <th>Case</th>
               <th>Status</th>
-              <% if !@submission.all_tests_passed? && can?(:read_result, @submission) %>
+              <% if !@submission.all_tests_passed? && (can? :read_results, @submission) %>
                 <th>Info</th>
               <% end %>
             </tr>
@@ -46,15 +46,15 @@
               <tr>
                 <td><%= tcr.test_case_name %></td>
                 <td>
-                  <% if cannot?(:read_result, @submission) %>
-                      <span class="h_i_d_d_e_n">Hidden</span>
+                  <% if cannot? :read_results, @submission %>
+                      <span class="hidden_status">Hidden</span>
                   <% elsif tcr.successful? %>
                     <span class="success">Ok</span>
                   <% else %>
                     <span class="failure">Fail</span>
                   <% end %>
                 </td>
-                <% if !@submission.all_tests_passed? && can?(:read_result, @submission) %>
+                <% if !@submission.all_tests_passed? && (can? :read_results, @submission) %>
                   <td>
                     <%= tcr.message %>
                     <% if tcr.exception != nil %>

--- a/app/views/submissions/_details.html.erb
+++ b/app/views/submissions/_details.html.erb
@@ -35,7 +35,7 @@
             <tr>
               <th>Case</th>
               <th>Status</th>
-              <% if !@submission.all_tests_passed? && can?(:see_result, @submission) %>
+              <% if !@submission.all_tests_passed? && can?(:read_result, @submission) %>
                 <th>Info</th>
               <% end %>
             </tr>
@@ -46,7 +46,7 @@
               <tr>
                 <td><%= tcr.test_case_name %></td>
                 <td>
-                  <% if cannot?(:see_result, @submission) %>
+                  <% if cannot?(:read_result, @submission) %>
                       <span class="h_i_d_d_e_n">Hidden</span>
                   <% elsif tcr.successful? %>
                     <span class="success">Ok</span>
@@ -54,7 +54,7 @@
                     <span class="failure">Fail</span>
                   <% end %>
                 </td>
-                <% if !@submission.all_tests_passed? && can?(:see_result, @submission) %>
+                <% if !@submission.all_tests_passed? && can?(:read_result, @submission) %>
                   <td>
                     <%= tcr.message %>
                     <% if tcr.exception != nil %>

--- a/app/views/submissions/_list.html.erb
+++ b/app/views/submissions/_list.html.erb
@@ -50,8 +50,10 @@
         </td>
         <% if show_awarded_points %>
           <td>
-            <% if can? :see_points, submission %>
+            <% if can? :see_result, submission %>
               <%= points_list(submission.points_list) %>
+            <% else %>
+              <span class="h_i_d_d_e_n">hidden</span>
             <% end %>
           </td>
         <% end %>

--- a/app/views/submissions/_list.html.erb
+++ b/app/views/submissions/_list.html.erb
@@ -50,7 +50,7 @@
         </td>
         <% if show_awarded_points %>
           <td>
-            <% if can? :see_result, submission %>
+            <% if can? :read_result, submission %>
               <%= points_list(submission.points_list) %>
             <% else %>
               <span class="h_i_d_d_e_n">hidden</span>

--- a/app/views/submissions/_list.html.erb
+++ b/app/views/submissions/_list.html.erb
@@ -50,10 +50,10 @@
         </td>
         <% if show_awarded_points %>
           <td>
-            <% if can? :read_result, submission %>
+            <% if can? :read_results, submission %>
               <%= points_list(submission.points_list) %>
             <% else %>
-              <span class="h_i_d_d_e_n">hidden</span>
+              <span class="hidden_status">hidden</span>
             <% end %>
           </td>
         <% end %>

--- a/app/views/submissions/_list.html.erb
+++ b/app/views/submissions/_list.html.erb
@@ -50,7 +50,9 @@
         </td>
         <% if show_awarded_points %>
           <td>
-            <%= points_list(submission.points_list) %>
+            <% if can? :see_points, submission %>
+              <%= points_list(submission.points_list) %>
+            <% end %>
           </td>
         <% end %>
         <% if show_review_column %>

--- a/app/views/submissions/_submission_details.html.erb
+++ b/app/views/submissions/_submission_details.html.erb
@@ -5,7 +5,7 @@
         <p>Processing...</p>
         <p class="processing-status"><!-- for JS to fill in --></p>
       <% elsif @submission.cannot_see_results?(current_user) %>
-        <p class="h_i_d_d_e_n">All test done - results are hidden</p>
+        <p class="h_i_d_d_e_n">All tests done - results are hidden</p>
       <% elsif @submission.all_tests_passed? %>
         <p class="success">All tests successful</p>
       <% elsif @submission.tests_ran? %>
@@ -16,7 +16,7 @@
     </div>
 
     <ul>
-      <% if can?(:see_result, @submission) && (!@submission.points_list.empty? || !@submission.exercise.nil?) %>
+      <% if can?(:read_result, @submission) && (!@submission.points_list.empty? || !@submission.exercise.nil?) %>
         <li>
           <%
              awarded_points = @submission.points_list

--- a/app/views/submissions/_submission_details.html.erb
+++ b/app/views/submissions/_submission_details.html.erb
@@ -4,8 +4,8 @@
       <% if !@submission.processed? %>
         <p>Processing...</p>
         <p class="processing-status"><!-- for JS to fill in --></p>
-      <% elsif @submission.cannot_see_results?(current_user) %>
-        <p class="h_i_d_d_e_n">All tests done - results are hidden</p>
+      <% elsif !@submission.can_see_results?(current_user) %>
+        <p class="hidden_status">All tests done - results are hidden</p>
       <% elsif @submission.all_tests_passed? %>
         <p class="success">All tests successful</p>
       <% elsif @submission.tests_ran? %>
@@ -16,7 +16,7 @@
     </div>
 
     <ul>
-      <% if can?(:read_result, @submission) && (!@submission.points_list.empty? || !@submission.exercise.nil?) %>
+      <% if (can? :read_results, @submission) && (!@submission.points_list.empty? || !@submission.exercise.nil?) %>
         <li>
           <%
              awarded_points = @submission.points_list
@@ -46,7 +46,7 @@
         <li>Needed <%= @submission.times_sent_to_sandbox %> processing attempts.</li>
       <% end %>
 
-      <% if can? :download, @submission %>
+      <% if can? :read, @submission %>
         <li><%= link_to "Download as zip", submission_full_zip_index_path(@submission) %></li>
       <% end %>
 

--- a/app/views/submissions/_submission_details.html.erb
+++ b/app/views/submissions/_submission_details.html.erb
@@ -4,6 +4,8 @@
       <% if !@submission.processed? %>
         <p>Processing...</p>
         <p class="processing-status"><!-- for JS to fill in --></p>
+      <% elsif @submission.cannot_see_results?(current_user) %>
+        <p class="h_i_d_d_e_n">All test done - results are hidden</p>
       <% elsif @submission.all_tests_passed? %>
         <p class="success">All tests successful</p>
       <% elsif @submission.tests_ran? %>
@@ -14,7 +16,7 @@
     </div>
 
     <ul>
-      <% unless @submission.points_list.empty? || @submission.exercise.nil? %>
+      <% if can?(:see_result, @submission) && (!@submission.points_list.empty? || !@submission.exercise.nil?) %>
         <li>
           <%
              awarded_points = @submission.points_list
@@ -44,11 +46,11 @@
         <li>Needed <%= @submission.times_sent_to_sandbox %> processing attempts.</li>
       <% end %>
 
-      <% if can? :read, @submission %>
+      <% if can? :download, @submission %>
         <li><%= link_to "Download as zip", submission_full_zip_index_path(@submission) %></li>
       <% end %>
 
-      <% if @exercise.solution && @exercise.solution.visible_to?(current_user) %>
+      <% if can? :read, @exercise.solution %>
         <li><%= link_to 'View suggested solution', exercise_solution_path(@exercise) %></li>
       <% end %>
 

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -23,7 +23,7 @@
       $.ajax({
         dataType: 'json',
         type: 'GET',
-        url: '<%= escape_javascript(course_submissions_path(@course, :format => :json, :row_format => 'datatables', :now => Time.now, :api_version => ApiVersion::API_VERSION)) %>',
+        url: '<%= escape_javascript(organization_course_submissions_path(@organization, @course, :format => :json, :row_format => 'datatables', :now => Time.now, :api_version => ApiVersion::API_VERSION)) %>',
         data: params,
         success: function(data) {
           rowCount += data.rows.length;
@@ -49,7 +49,3 @@
 
 
 <%= show_submission_list([], :invoke_datatables => false) %>
-
-<div class="link-back">
-  <%= link_to 'Back', organization_course_path(@course) %>
-</div>

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -12,13 +12,13 @@
   <% if @submission.tests_ran? %>
     <li><a href="#testResults">Test Results</a></li>
   <% end %>
-  <% unless @submission.stdout.blank? %>
+  <% if !@submission.stdout.blank? && can?(:read_result, @submission) %>
     <li><a href="#stdout" >Stdout</a></li>
   <% end %>
-  <% unless @submission.stderr.blank? %>
+  <% if !@submission.stderr.blank? && can?(:read_result, @submission) %>
     <li><a href="#stderr" >Stderr</a></li>
   <% end %>
-  <% unless @submission.valgrind.blank? %>
+  <% if !@submission.valgrind.blank? && can?(:read_result, @submission) %>
     <li><a href="#valgrind" >Valgrind</a></li>
   <% end %>
   <% if can?(:read_vm_log, @submission) && !@submission.vm_log.blank? %>
@@ -43,19 +43,19 @@
         </div>
       <% end %>
 
-      <% unless @submission.stdout.blank? %>
+      <% if !@submission.stdout.blank? && can?(:read_results, @submission) %>
         <div class="tab-pane" id="stdout">
           <%= render 'submissions/stdout' %>
         </div>
       <% end %>
 
-      <% unless @submission.stderr.blank? %>
+      <% if !@submission.stderr.blank? && can?(:read_results, @submission) %>
         <div class="tab-pane" id="stderr">
           <%= render 'submissions/stderr' %>
         </div>
       <% end %>
 
-      <% unless @submission.valgrind.blank? %>
+      <% if !@submission.valgrind.blank? && can?(:read_results, @submission) %>
         <div class="tab-pane" id="valgrind">
           <%= render 'submissions/valgrind' %>
         </div>

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -12,16 +12,16 @@
   <% if @submission.tests_ran? %>
     <li><a href="#testResults">Test Results</a></li>
   <% end %>
-  <% if !@submission.stdout.blank? && can?(:read_result, @submission) %>
+  <% if !@submission.stdout.blank? && (can? :read_results, @submission) %>
     <li><a href="#stdout" >Stdout</a></li>
   <% end %>
-  <% if !@submission.stderr.blank? && can?(:read_result, @submission) %>
+  <% if !@submission.stderr.blank? && (can? :read_results, @submission) %>
     <li><a href="#stderr" >Stderr</a></li>
   <% end %>
-  <% if !@submission.valgrind.blank? && can?(:read_result, @submission) %>
+  <% if !@submission.valgrind.blank? && (can? :read_results, @submission) %>
     <li><a href="#valgrind" >Valgrind</a></li>
   <% end %>
-  <% if can?(:read_vm_log, @submission) && !@submission.vm_log.blank? %>
+  <% if !@submission.vm_log.blank? && (can? :read_vm_log, @submission) %>
     <li class=""><a href="#logs">Logs</a></li>
   <% end %>
   <li class="active"><a href="#files">Files</a></li>
@@ -43,25 +43,25 @@
         </div>
       <% end %>
 
-      <% if !@submission.stdout.blank? && can?(:read_results, @submission) %>
+      <% if !@submission.stdout.blank? && (can? :read_results, @submission) %>
         <div class="tab-pane" id="stdout">
           <%= render 'submissions/stdout' %>
         </div>
       <% end %>
 
-      <% if !@submission.stderr.blank? && can?(:read_results, @submission) %>
+      <% if !@submission.stderr.blank? && (can? :read_results, @submission) %>
         <div class="tab-pane" id="stderr">
           <%= render 'submissions/stderr' %>
         </div>
       <% end %>
 
-      <% if !@submission.valgrind.blank? && can?(:read_results, @submission) %>
+      <% if !@submission.valgrind.blank? && (can? :read_results, @submission) %>
         <div class="tab-pane" id="valgrind">
           <%= render 'submissions/valgrind' %>
         </div>
       <% end %>
 
-      <% if can?(:read_vm_log, @submission) && !@submission.vm_log.blank? %>
+      <% if !@submission.vm_log.blank? && (can? :read_vm_log, @submission) %>
         <div class="tab-pane" id="logs">
           <%= render 'submissions/logs' %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ TmcServer::Application.routes.draw do
         get 'manage_unlocks'
         post 'save_unlocks'
         get 'manage_exercises'
+        post 'toggle_submission_result_visibility'
         resources :emails, only: [:index]
       end
 

--- a/db/migrate/20150702084350_add_hide_submission_result_to_course.rb
+++ b/db/migrate/20150702084350_add_hide_submission_result_to_course.rb
@@ -1,5 +1,0 @@
-class AddHideSubmissionResultToCourse < ActiveRecord::Migration
-  def change
-    add_column :courses, :hide_submission_result, :boolean, default: false
-  end
-end

--- a/db/migrate/20150702084350_add_hide_submission_result_to_course.rb
+++ b/db/migrate/20150702084350_add_hide_submission_result_to_course.rb
@@ -1,0 +1,5 @@
+class AddHideSubmissionResultToCourse < ActiveRecord::Migration
+  def change
+    add_column :courses, :hide_submission_result, :boolean, default: false
+  end
+end

--- a/db/migrate/20150702084350_add_hide_submission_results_to_course.rb
+++ b/db/migrate/20150702084350_add_hide_submission_results_to_course.rb
@@ -1,0 +1,5 @@
+class AddHideSubmissionResultsToCourse < ActiveRecord::Migration
+  def change
+    add_column :courses, :hide_submission_results, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -86,7 +86,7 @@ ActiveRecord::Schema.define(version: 20150702084350) do
     t.string   "title"
     t.string   "material_url"
     t.integer  "course_template_id"
-    t.boolean  "hide_submission_result",         default: false
+    t.boolean  "hide_submission_results",        default: false
   end
 
   add_index "courses", ["organization_id"], name: "index_courses_on_organization_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150625081824) do
+ActiveRecord::Schema.define(version: 20150702084350) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(version: 20150625081824) do
     t.string   "title"
     t.string   "material_url"
     t.integer  "course_template_id"
+    t.boolean  "hide_submission_result",         default: false
   end
 
   add_index "courses", ["organization_id"], name: "index_courses_on_organization_id", using: :btree

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -456,4 +456,40 @@ describe CoursesController, type: :controller do
       expect(response.code.to_i).to eq(401)
     end
   end
+
+  describe 'POST toggle_submission_result_visibility' do
+    before :each do
+      @course = FactoryGirl.create :course, organization: @organization
+    end
+
+    describe 'when teacher' do
+      it 'toggles visibility of submsission results' do
+        controller.current_user = @teacher
+        post :toggle_submission_result_visibility, organization_id: @organization.slug, id: @course.id
+        @course.reload
+        expect(@course.hide_submission_result).to be true
+        expect(response).to redirect_to(organization_course_path)
+      end
+    end
+
+    describe 'when the assistant of the course' do
+      it 'toggles visibility of submsission results' do
+        Assistantship.create(user: @user, course: @course)
+        controller.current_user = @user
+        post :toggle_submission_result_visibility, organization_id: @organization.slug, id: @course.id
+        @course.reload
+        expect(@course.hide_submission_result).to be true
+        expect(response).to redirect_to(organization_course_path)
+      end
+    end
+
+    describe 'when non-teacher or non-admin' do
+      it 'acces denied' do
+        controller.current_user = @user
+        post :toggle_submission_result_visibility, organization_id: @organization.slug, id: @course.id
+        @course.reload
+        expect(response.code.to_i).to eq(401)
+      end
+    end
+  end
 end

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -467,7 +467,7 @@ describe CoursesController, type: :controller do
         controller.current_user = @teacher
         post :toggle_submission_result_visibility, organization_id: @organization.slug, id: @course.id
         @course.reload
-        expect(@course.hide_submission_result).to be true
+        expect(@course.hide_submission_results).to be true
         expect(response).to redirect_to(organization_course_path)
       end
     end
@@ -478,7 +478,7 @@ describe CoursesController, type: :controller do
         controller.current_user = @user
         post :toggle_submission_result_visibility, organization_id: @organization.slug, id: @course.id
         @course.reload
-        expect(@course.hide_submission_result).to be true
+        expect(@course.hide_submission_results).to be true
         expect(response).to redirect_to(organization_course_path)
       end
     end

--- a/spec/controllers/points_controller_spec.rb
+++ b/spec/controllers/points_controller_spec.rb
@@ -31,7 +31,7 @@ describe PointsController, type: :controller do
       end
 
       it 'should not show a page when submission result are hidden' do
-        @course.hide_submission_result = true
+        @course.hide_submission_results = true
         @course.save!
         get :index, organization_id: @organization.slug, course_id: @course.id
         expect(response.code.to_i).to eq(401)
@@ -63,7 +63,7 @@ describe PointsController, type: :controller do
       end
 
       it 'should not show a page when submission result are hidden' do
-        @course.hide_submission_result = true
+        @course.hide_submission_results = true
         @course.save!
         get :show, organization_id: @organization.slug, course_id: @course.id, id: @sheetname
         expect(response.code.to_i).to eq(401)

--- a/spec/controllers/points_controller_spec.rb
+++ b/spec/controllers/points_controller_spec.rb
@@ -3,35 +3,44 @@ require 'spec_helper'
 
 describe PointsController, type: :controller do
   render_views
+
   before :each do
+    @user = FactoryGirl.create(:user)
     @organization = FactoryGirl.create(:accepted_organization)
-    @course = FactoryGirl.create(:course)
-    @course.organization = @organization
+    @course = FactoryGirl.create :course, organization: @organization
     @sheetname = 'testsheet'
-    @exercise = FactoryGirl.create(:exercise, course: @course,
-                                              gdocs_sheet: @sheetname)
-    @admin = FactoryGirl.create(:admin)
+    @exercise = FactoryGirl.create(:exercise, course: @course, gdocs_sheet: @sheetname)
+    @submission = FactoryGirl.create(:submission,
+                                     course: @course,
+                                     user: @user,
+                                     exercise: @exercise)
+    @available_point = FactoryGirl.create(:available_point, exercise: @exercise)
+    @awarded_point = FactoryGirl.create(:awarded_point,
+                                        course: @course,
+                                        name: @available_point.name,
+                                        submission: @submission,
+                                        user: @user)
+    controller.current_user = @user
+  end
+
+  describe 'GET index' do
+    describe 'when user has participated in a course' do
+      it 'should show a page' do
+        get :index, organization_id: @organization.slug, course_id: @course.id
+        expect(response).to be_success
+      end
+
+      it 'should not show a page when submission result are hidden' do
+        @course.hide_submission_result = true
+        @course.save!
+        get :index, organization_id: @organization.slug, course_id: @course.id
+        expect(response.code.to_i).to eq(401)
+      end
+    end
   end
 
   describe 'GET show' do
     describe 'when user has participated in a course' do
-      before :each do
-        controller.current_user = @admin
-        @user = FactoryGirl.create(:user)
-        @submission = FactoryGirl.create(:submission,
-                                         course: @course,
-                                         user: @user,
-                                         exercise: @exercise)
-        @available_point = FactoryGirl.create(:available_point,
-                                              exercise: @exercise)
-
-        @awarded_point = FactoryGirl.create(:awarded_point,
-                                            course: @course,
-                                            name: @available_point.name,
-                                            submission: @submission,
-                                            user: @user)
-      end
-
       it 'should show a page' do
         get :show, organization_id: @organization.slug,
             course_id: @course.id, id: @sheetname
@@ -51,6 +60,13 @@ describe PointsController, type: :controller do
       it 'should contain a success marker' do
         get :show, organization_id: @organization.slug, course_id: @course.id, id: @sheetname
         expect(response.body).to have_content('✔')
+      end
+
+      it 'should not show a page when submission result are hidden' do
+        @course.hide_submission_result = true
+        @course.save!
+        get :show, organization_id: @organization.slug, course_id: @course.id, id: @sheetname
+        expect(response.code.to_i).to eq(401)
       end
     end
   end

--- a/spec/controllers/submission_controller_spec.rb
+++ b/spec/controllers/submission_controller_spec.rb
@@ -1,0 +1,127 @@
+require 'spec_helper'
+
+describe SubmissionsController, type: :controller do
+  before :each do
+    @user = FactoryGirl.create(:user)
+    @organization = FactoryGirl.create(:accepted_organization)
+    @course = FactoryGirl.create :course, organization: @organization
+    @exercise = FactoryGirl.create(:exercise, course: @course, gdocs_sheet: @sheetname)
+    @available_point = FactoryGirl.create(:available_point, exercise: @exercise)
+    @submission = FactoryGirl.create(:submission,
+                                     course: @course,
+                                     user: @user,
+                                     exercise: @exercise)
+    @awarded_point = FactoryGirl.create(:awarded_point,
+                                        course: @course,
+                                        name: @available_point.name,
+                                        submission: @submission,
+
+                                        user: @user)
+    @submission.awarded_points << @awarded_point
+    @submission.save!
+    controller.current_user = @user
+  end
+
+  describe 'GET show as JSON ' do
+
+    describe 'when still processing submission' do
+      it "should return 'processing' status" do
+        @submission.processed = false
+        @submission.save!
+        get :show, id: @submission.id, format: :json, api_version: ApiVersion::API_VERSION
+        json = JSON.parse response.body
+        check_common_keys(json)
+        expect(json).to have_key 'submissions_before_this'
+        expect(json).to have_key 'total_unprocessed'
+        expect(json['status']).to eq('processing')
+      end
+    end
+
+    describe 'when all test passed' do
+      it "should return 'ok' status and right fields" do
+        @submission.all_tests_passed = true
+        @submission.save!
+        get :show, id: @submission.id, format: :json, api_version: ApiVersion::API_VERSION
+        json = JSON.parse response.body
+        check_common_keys(json)
+        expect(json).to have_key 'test_cases'
+        expect(json).to have_key 'feedback_questions'
+        expect(json).to have_key 'feedback_answer_url'
+        expect(json['status']).to eq('ok')
+      end
+    end
+
+    describe 'when test failed' do
+      it "should return 'fail' status and right field" do
+        get :show, id: @submission.id, format: :json, api_version: ApiVersion::API_VERSION
+        json = JSON.parse response.body
+        check_common_keys(json)
+        expect(json).to have_key 'test_cases'
+        expect(json['status']).to eq('fail')
+      end
+    end
+
+
+    describe 'when there is pretest error' do
+      it "should return 'error' status and right field" do
+        @submission.pretest_error = 'some funny error'
+        @submission.save!
+        get :show, id: @submission.id, format: :json, api_version: ApiVersion::API_VERSION
+        json = JSON.parse response.body
+        check_common_keys(json)
+        expect(json).to have_key 'error'
+        expect(json['status']).to eq('error')
+        expect(json['error']).to eq('some funny error')
+      end
+    end
+
+    describe 'when submission results are hidden' do
+      before :each do
+        @course.hide_submission_result = true
+        @course.save!
+      end
+
+      it "should return 'hidden' status and right field (processed and tests passed)" do
+        @submission.all_tests_passed = true
+        @submission.points = 'some points'
+        @submission.save!
+        get :show, id: @submission.id, format: :json, api_version: ApiVersion::API_VERSION
+        json = JSON.parse response.body
+        check_common_keys(json)
+        expect(json).to have_key 'test_cases'
+        expect(json['status']).to eq('hidden')
+        expect(json['all_tests_passed']).to be nil
+        expect(json['test_cases']).to be nil
+        expect(json['points']).to be nil
+        expect(json['validations']).to be nil
+        expect(json['valgrind']).to be nil
+      end
+
+      it "should return 'hidden' status (processed but failed tests)" do
+        get :show, id: @submission.id, format: :json, api_version: ApiVersion::API_VERSION
+        json = JSON.parse response.body
+        expect(json['status']).to eq('hidden')
+      end
+    end
+  end
+end
+
+def check_common_keys(json)
+  expect(json).to have_key 'api_version'
+  expect(json).to have_key 'all_tests_passed'
+  expect(json).to have_key 'user_id'
+  expect(json).to have_key 'course'
+  expect(json).to have_key 'exercise_name'
+  expect(json).to have_key 'status'
+  expect(json).to have_key 'points'
+  expect(json).to have_key 'validations'
+  expect(json).to have_key 'valgrind'
+  expect(json).to have_key 'solution_url'
+  expect(json).to have_key 'submitted_at'
+  expect(json).to have_key 'processing_time'
+  expect(json).to have_key 'reviewed'
+  expect(json).to have_key 'requests_review'
+  expect(json).to have_key 'paste_url'
+  expect(json).to have_key 'message_for_paste'
+  expect(json).to have_key 'missing_review_points'
+end

--- a/spec/controllers/submission_controller_spec.rb
+++ b/spec/controllers/submission_controller_spec.rb
@@ -77,7 +77,7 @@ describe SubmissionsController, type: :controller do
 
     describe 'when submission results are hidden' do
       before :each do
-        @course.hide_submission_result = true
+        @course.hide_submission_results = true
         @course.save!
       end
 

--- a/spec/features/teacher_hides_submission_results_spec.rb
+++ b/spec/features/teacher_hides_submission_results_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe 'Teacher can hide submission results from users', feature: true do
+  include IntegrationTestActions
+
+  before :each do
+    @organization = FactoryGirl.create :accepted_organization
+    @teacher = FactoryGirl.create :user, password: 'xooxer'
+    @user = FactoryGirl.create :user, password: 'foobar'
+    Teachership.create! user: @teacher, organization: @organization
+    @course = FactoryGirl.create :course, organization: @organization
+    @course.hide_submission_result = true
+    @course.save!
+    @exercise = FactoryGirl.create(:exercise, course: @course)
+    @available_point = FactoryGirl.create(:available_point, exercise: @exercise)
+    @submission = FactoryGirl.create(:submission,
+                                     course: @course,
+                                     user: @user,
+                                     exercise: @exercise)
+    @awarded_point = FactoryGirl.create(:awarded_point,
+                                        course: @course,
+                                        name: @available_point.name,
+                                        submission: @submission,
+                                        user: @user)
+    @submission.awarded_points << @awarded_point
+    @submission.save!
+    visit '/'
+  end
+
+  def visit_course
+    visit "/org/#{@organization.slug}/courses/#{@course.id}"
+  end
+
+  scenario "Teacher can see button 'Unhide submisson results' when result are hidden" do
+    log_in_as(@teacher.username, 'xooxer')
+    visit_course
+    expect(page).to have_content('Unhide submission results')
+  end
+
+  scenario 'In course page user can not see results of submission and link to points page' do
+    log_in_as(@user.username, 'foobar')
+    visit_course
+    expect(page).to_not have_link('View points')
+    expect(page.find_by_id('submissions').find('tr', text: @user.username)).to have_content('Hidden')
+  end
+
+  scenario 'In My stats page user can not see results of submission' do
+    log_in_as(@user.username, 'foobar')
+    visit_course
+    click_link('My stats')
+    expect(page).to have_content('For this course points are not visible')
+    expect(page.find_by_id('submissions').find('tr', text: @user.username)).to have_content('Hidden')
+  end
+
+  scenario 'In submission page user can not see results of submission' do
+    FactoryGirl.create :submission_data, submission: @submission
+    tcr = FactoryGirl.create :test_case_run, submission: @submission
+    log_in_as(@user.username, 'foobar')
+    visit_course
+    click_link('Details')
+    expect(page).to have_content('All test done - results are hidden')
+    expect(page).to_not have_content('Got 1 out of 1 point')
+    expect(page).to_not have_link('View suggested solution')
+    click_link('Test Results')
+    expect(page).to have_content('Test Cases')
+    expect(find('tr', text: tcr.test_case_name)).to have_content('Hidden')
+    expect(find('tr', text: tcr.test_case_name).all('td').count).to eq(2)
+  end
+end

--- a/spec/features/teacher_hides_submission_results_spec.rb
+++ b/spec/features/teacher_hides_submission_results_spec.rb
@@ -9,7 +9,7 @@ describe 'Teacher can hide submission results from users', feature: true do
     @user = FactoryGirl.create :user, password: 'foobar'
     Teachership.create! user: @teacher, organization: @organization
     @course = FactoryGirl.create :course, organization: @organization
-    @course.hide_submission_result = true
+    @course.hide_submission_results = true
     @course.save!
     @exercise = FactoryGirl.create(:exercise, course: @course)
     @available_point = FactoryGirl.create(:available_point, exercise: @exercise)

--- a/spec/features/teacher_hides_submission_results_spec.rb
+++ b/spec/features/teacher_hides_submission_results_spec.rb
@@ -58,12 +58,32 @@ describe 'Teacher can hide submission results from users', feature: true do
     log_in_as(@user.username, 'foobar')
     visit_course
     click_link('Details')
-    expect(page).to have_content('All test done - results are hidden')
+    expect(page).to have_content('All tests done - results are hidden')
     expect(page).to_not have_content('Got 1 out of 1 point')
     expect(page).to_not have_link('View suggested solution')
     click_link('Test Results')
     expect(page).to have_content('Test Cases')
     expect(find('tr', text: tcr.test_case_name)).to have_content('Hidden')
     expect(find('tr', text: tcr.test_case_name).all('td').count).to eq(2)
+  end
+
+  scenario 'when c language exercise then in submission page user can not see results of submission' do
+    FactoryGirl.create :submission_data, submission: @submission
+    tcr = FactoryGirl.create :test_case_run, submission: @submission
+    @submission.stdout = 'some stdout text'
+    @submission.stderr = 'some stderr text'
+    @submission.valgrind = 'some valgrind text'
+    @submission.save!
+    log_in_as(@user.username, 'foobar')
+    visit_course
+    click_link('Details')
+    expect(page).to have_content('All tests done - results are hidden')
+    expect(page).to_not have_content('Got 1 out of 1 point')
+    expect(page).to_not have_link('View suggested solution')
+    click_link('Test Results')
+    expect(page).to have_content('Test Cases')
+    expect(find('tr', text: tcr.test_case_name)).to have_content('Hidden')
+    expect(find('tr', text: tcr.test_case_name).all('td').count).to eq(2)
+    expect(find_by_id('myTab').all('li').count).to eq(2)
   end
 end

--- a/spec/integration/running_tests/general_spec.rb
+++ b/spec/integration/running_tests/general_spec.rb
@@ -43,7 +43,7 @@ describe RemoteSandboxForTesting, type: :request, integration: true do
 
       RemoteSandboxForTesting.run_submission(@submission)
 
-      expect(@submission.status).to eq(:error)
+      expect(@submission.status(@user)).to eq(:error)
       expect(@submission.pretest_error).to match(/Compilation error/)
     end
 
@@ -100,6 +100,6 @@ describe RemoteSandboxForTesting, type: :request, integration: true do
     make_setup 'UsingToolsJar'
     @setup.make_zip
     RemoteSandboxForTesting.run_submission(@submission)
-    expect(@submission.status).to eq(:ok)
+    expect(@submission.status(@user)).to eq(:ok)
   end
 end

--- a/spec/lib/submission_processor_spec.rb
+++ b/spec/lib/submission_processor_spec.rb
@@ -55,13 +55,15 @@ describe SubmissionProcessor do
         expect_no_processing
         SubmissionProcessor.new.reprocess_timed_out_submissions
       end
+
       it 'should mark it as processed and having an error' do
+        user = FactoryGirl.create :user
         SubmissionProcessor.new.reprocess_timed_out_submissions
         @sub.reload
         expect(@sub).to be_processed
         expect(@sub.pretest_error).not_to be_empty
         expect(@sub.secret_token).to be_nil
-        expect(@sub.status).to eq(:error)
+        expect(@sub.status(user)).to eq(:error)
       end
     end
 

--- a/spec/models/stats_spec.rb
+++ b/spec/models/stats_spec.rb
@@ -43,7 +43,7 @@ describe Stats, type: :model do
   def create_successful_submission(opts)
     sub = FactoryGirl.create(:submission, opts.merge(all_tests_passed: true))
     FactoryGirl.create(:test_case_run, submission: sub, successful: true)
-    expect(sub.status).to eq(:ok)
+    expect(sub.status(opts[:user])).to eq(:ok)
     sub
   end
 end


### PR DESCRIPTION
Especially for machine test purposes, added ability to hide submission results for course. Teacher can toggle that on/off. If results are hidded, student can't see anywhere, if the tests passed or not.