### PR TITLE
Suggestion for role indicator in all views

### DIFF
--- a/app/views/twitter-bootstrap/_breadcrumbs.html.erb
+++ b/app/views/twitter-bootstrap/_breadcrumbs.html.erb
@@ -10,5 +10,12 @@
     <li class="active">
       <%= @breadcrumbs.last[:name] %>
     </li>
+    <% if current_user.administrator? %>
+      <li class="pull-right">[Role: Admin]</li>
+    <% elsif (defined? @organization) && can?(:teach, @organization) %>
+      <li class="pull-right">[Role: Teacher]</li>
+    <% elsif (defined? @course) && can?(:teach, @course) %>
+      <li class="pull-right">[Role: Course-assistant]</li>
+    <% end %>
   </ul>
 <% end %>


### PR DESCRIPTION
This would tell in breadcrumbs bar right part, if current user has some special role in this specific content.

For admins, admin-role is always visible, for teachers always when their organization is set, and for course assistans for their assisteds course content.

Normal users don't see anything extra.