### PR TITLE
Improvements for course template admin interface

### DIFF
--- a/app/controllers/course_templates_controller.rb
+++ b/app/controllers/course_templates_controller.rb
@@ -13,6 +13,12 @@ class CourseTemplatesController < ApplicationController
     end
   end
 
+  def show
+    authorize! :read, CourseTemplate
+    add_breadcrumb 'Course templates', course_templates_path
+    add_breadcrumb "#{@course_template.title}"
+  end
+
   def new
     authorize! :create, CourseTemplate
     add_breadcrumb 'Course templates', course_templates_path

--- a/app/views/course_templates/_table_row.html.erb
+++ b/app/views/course_templates/_table_row.html.erb
@@ -6,7 +6,13 @@
   <td><%= link_to 'source', course_template.source_url %></td>
   <td><%= course_template.expires_at.strftime('%d.%m.%Y') unless course_template.expires_at.nil? %></td>
   <td><%= link_to course_template.courses.count, course_template_path(course_template) %></td>
-  <td><%= link_to 'Refresh', refresh_course_template_path(course_template), method: :post, class: "btn btn-mini btn-primary" %></td>
+  <% refreshable = course_template.courses.count > 0 %>
+  <td>
+    <%= link_to_if(refreshable, 'Refresh', refresh_course_template_path(course_template),
+                   class: "btn btn-mini btn-primary",
+                   data: { confirm: 'Are you sure? This will refresh all courses made from this template.' },
+                   method: :post) {'-'} %>
+  </td>
   <td><%= link_to 'Edit', edit_course_template_path(course_template), class: "btn btn-mini btn-info" %></td>
   <td><%= link_to 'Destroy', course_template, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-mini btn-danger" %></td>
   <td>

--- a/app/views/course_templates/_table_row.html.erb
+++ b/app/views/course_templates/_table_row.html.erb
@@ -14,7 +14,6 @@
                    method: :post) {'-'} %>
   </td>
   <td><%= link_to 'Edit', edit_course_template_path(course_template), class: "btn btn-mini btn-info" %></td>
-  <td><%= link_to 'Destroy', course_template, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-mini btn-danger" %></td>
   <td>
     <% if course_template.hidden %>
       <%= link_to 'unhide', toggle_hidden_course_template_path(course_template), method: :post, class: "btn btn-mini btn-danger" %>

--- a/app/views/course_templates/_table_row.html.erb
+++ b/app/views/course_templates/_table_row.html.erb
@@ -1,10 +1,11 @@
 <tr>
-  <td><%= course_template.name %></td>
+  <td><%= link_to course_template.name, course_template_path(course_template) %></td>
   <td><%= course_template.title %></td>
   <td><%= course_template.description %></td>
   <td><%= link_to 'material', course_template.material_url unless course_template.material_url.blank? %></td>
   <td><%= link_to 'source', course_template.source_url %></td>
   <td><%= course_template.expires_at.strftime('%d.%m.%Y') unless course_template.expires_at.nil? %></td>
+  <td><%= link_to course_template.courses.count, course_template_path(course_template) %></td>
   <td><%= link_to 'Refresh', refresh_course_template_path(course_template), method: :post, class: "btn btn-mini btn-primary" %></td>
   <td><%= link_to 'Edit', edit_course_template_path(course_template), class: "btn btn-mini btn-info" %></td>
   <td><%= link_to 'Destroy', course_template, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-mini btn-danger" %></td>

--- a/app/views/course_templates/index.html.erb
+++ b/app/views/course_templates/index.html.erb
@@ -11,6 +11,7 @@
       <th>Material url</th>
       <th>Source url</th>
       <th>Expires at</th>
+      <th>Courses made</th>
       <th colspan="3"></th>
     </tr>
     </thead>
@@ -34,6 +35,7 @@
       <th>Material url</th>
       <th>Source url</th>
       <th>Expires at</th>
+      <th>Courses made</th>
       <th colspan="3"></th>
     </tr>
     </thead>
@@ -48,4 +50,4 @@
 
 <br>
 
-<%= link_to 'New Course template', new_course_template_path %>
+<%= link_to 'New Course template', new_course_template_path, class: 'btn btn-mini' %>

--- a/app/views/course_templates/show.html.erb
+++ b/app/views/course_templates/show.html.erb
@@ -1,0 +1,51 @@
+<h1><%= @course_template.title %></h1>
+
+<p>
+  <strong>Name:</strong>
+  <%= @course_template.name %>
+</p>
+
+<p>
+  <strong>Title:</strong>
+  <%= @course_template.title %>
+</p>
+
+<p>
+  <strong>Description:</strong>
+  <%= @course_template.description %>
+</p>
+
+<p>
+  <strong>Material url:</strong>
+  <%= link_to @course_template.material_url %>
+</p>
+
+<p>
+  <strong>Sourse url:</strong>
+  <%= @course_template.source_url %>
+</p>
+
+<p>
+  <strong>Cache version:</strong>
+  <%= @course_template.cache_version %>
+</p>
+
+<p>
+  <strong>Expires at:</strong>
+  <%= @course_template.expires_at %>
+</p>
+
+<p>
+  <strong>Name:</strong>
+  <%= @course_template.name %>
+</p>
+
+<%= link_to 'Edit', edit_course_template_path(@course_template), class: "btn btn-mini btn-info" %>
+
+<h4>Courses made from this template</h4>
+
+<ul>
+  <% @course_template.courses.each do |course| %>
+      <li><%= link_to course.name, organization_course_path(course.organization, course) %>, <%= course.organization.name %></li>
+  <% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ resources :organizations, except: :destory, path: 'org' do
     resources :stats, only: [:index]
   end
 
-  resources :course_templates, except: :show do
+  resources :course_templates do
     member do
       post 'toggle_hidden', to: 'course_templates#toggle_hidden'
       post 'refresh'


### PR DESCRIPTION
- Don't show destroy button
- Don't show refresh, if template doesn't have courses yet
- Refresh button has also warning+confirmation
- Added show-view for templates, which includes list of courses made from this template. Show might be needed also later when all information can't be shown on index page.