### PR TITLE
Made repo validation to use git ls-remote

### DIFF
--- a/app/controllers/course_templates_controller.rb
+++ b/app/controllers/course_templates_controller.rb
@@ -40,7 +40,7 @@ class CourseTemplatesController < ApplicationController
   def update
     authorize! :edit, CourseTemplate
     if @course_template.update(course_template_params)
-      redirect_to course_templates_path, notice: 'Course template was successfully updated.'
+      redirect_to course_templates_path, notice: "Course template '#{@course_template.name}' was successfully updated."
     else
       render :edit
     end

--- a/app/models/course_template.rb
+++ b/app/models/course_template.rb
@@ -48,24 +48,10 @@ class CourseTemplate < ActiveRecord::Base
 
   def valid_git_repo?
     timeout = 10
-    safe_source_url = Shellwords.escape(source_url)
-    safe_git_branch = Shellwords.escape(git_branch)
-    cmd = "timeout #{timeout+1} git ls-remote --exit-code #{safe_source_url} #{safe_git_branch}"
-    output = ''
-    begin
-      Timeout::timeout(timeout) do
-        output = `#{cmd} 2>&1`
-      end
-    rescue Timeout::Error
-      errors.add(:base, "Cannot clone repository, timeout expired, git ls-remote output: #{output}")
-      return false
-    end
-    status = $?
-    unless status.success?
-      errors.add(:base, "Cannot clone repository, git ls-remote output: #{output}")
-      return false
-    end
+    sh!('git', 'ls-remote', '--exit-code', source_url, git_branch, { timeout: timeout })
     true
+  rescue StandardError => e
+    errors.add(:base, 'Cannot clone repository. Error: ' + e.to_s)
   end
 
   def valid_source_backend?

--- a/app/models/course_template.rb
+++ b/app/models/course_template.rb
@@ -47,9 +47,8 @@ class CourseTemplate < ActiveRecord::Base
   end
 
   def valid_git_repo?
-    timeout = 10
-    sh!('git', 'ls-remote', '--exit-code', source_url, git_branch, { timeout: timeout })
-    true
+    result = sh!('git', 'ls-remote', '--exit-code', source_url, git_branch, timeout: 10)
+    result[:status].success?
   rescue StandardError => e
     errors.add(:base, 'Cannot clone repository. Error: ' + e.to_s)
   end

--- a/app/models/course_template.rb
+++ b/app/models/course_template.rb
@@ -47,12 +47,13 @@ class CourseTemplate < ActiveRecord::Base
   end
 
   def valid_git_repo?
+    timeout = 10
     safe_source_url = Shellwords.escape(source_url)
     safe_git_branch = Shellwords.escape(git_branch)
-    cmd = "git ls-remote --exit-code #{safe_source_url} #{safe_git_branch}"
+    cmd = "timeout #{timeout+1} git ls-remote --exit-code #{safe_source_url} #{safe_git_branch}"
     output = ''
     begin
-      Timeout::timeout(5) do
+      Timeout::timeout(timeout) do
         output = `#{cmd} 2>&1`
       end
     rescue Timeout::Error

--- a/lib/system_commands.rb
+++ b/lib/system_commands.rb
@@ -40,7 +40,7 @@ module SystemCommands
     output = `#{cmd} 2>&1`
     status = $?
 
-    fail "Time out for command ''#{cmd}'', status #{status.inspect}. The output follows:\n#{output}" if status.exitstatus == 124
+    fail "Command '#{cmd}' timed out, status #{status.inspect}. The output follows:\n#{output}" if status.exitstatus == 124
     fail "Command `#{cmd}` failed with status #{status.inspect}. The output follows:\n#{output}" unless status.success?
     fail "Expected no output from `#{cmd}` but got: #{output}" if options[:assert_silent] && !output.empty?
 

--- a/spec/lib/system_commands_spec.rb
+++ b/spec/lib/system_commands_spec.rb
@@ -13,4 +13,10 @@ describe SystemCommands do
       sh!('sleep', 2)
     }.not_to raise_error
   end
+
+  it 'should fail if expecting no output' do
+    expect {
+      sh!('echo', 'Hello', assert_silent: true)
+    }.to raise_error
+  end
 end

--- a/spec/lib/system_commands_spec.rb
+++ b/spec/lib/system_commands_spec.rb
@@ -2,21 +2,21 @@ require 'spec_helper'
 
 describe SystemCommands do
 
-  it 'should return error on timeout properly' do
+  it 'should return error when when command exit status is non-zero' do
     expect {
-      sh!('sleep', 2, { timeout: 1 })
+      sh!('false')
     }.to raise_error
   end
 
-  it 'should not return error without timeout set' do
+  it 'should return error on timeout properly' do
     expect {
-      sh!('sleep', 2)
-    }.not_to raise_error
+      sh!('sleep', 2, { timeout: 1 })
+    }.to raise_error(/timeout/)
   end
 
   it 'should fail if expecting no output' do
     expect {
       sh!('echo', 'Hello', assert_silent: true)
-    }.to raise_error
+    }.to raise_error(/Expected no output/)
   end
 end

--- a/spec/lib/system_commands_spec.rb
+++ b/spec/lib/system_commands_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe SystemCommands do
+
+  it 'should return error on timeout properly' do
+    expect {
+      sh!('sleep', 2, { timeout: 1 })
+    }.to raise_error
+  end
+
+  it 'should not return error without timeout set' do
+    expect {
+      sh!('sleep', 2)
+    }.not_to raise_error
+  end
+end

--- a/spec/support/submission_test_setup.rb
+++ b/spec/support/submission_test_setup.rb
@@ -22,7 +22,8 @@ class SubmissionTestSetup
     should_save = options[:save]
     @user = options[:user] || create_user
 
-    @repo_path = 'remote_repo'
+    @test_tmp_dir = "#{::Rails.root}/tmp/tests"
+    @repo_path = @test_tmp_dir + '/fake_remote_repo'
     create_bare_repo(@repo_path)
 
     @course = Course.create!(name: course_name, title: course_name, source_backend: 'git', source_url: @repo_path, organization: organization)


### PR DESCRIPTION
Using git ls-remote to check repo validity instead of whole cloning. Timeout check is for situations where git command tries to ask login, and would be left waiting forever without.