### PR TITLE
Added organization support for participant list

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -253,6 +253,10 @@ class Ability
       can :view_participant_information, User do |u|
         !user.guest? && u.readable_by?(user)
       end
+
+      can :view_participant_list, Organization do |o|
+        can?(:teach, o)
+      end
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,13 @@ class User < ActiveRecord::Base
       .group('users.id')
   end
 
+  # TODO: Later after enrollment has implemented, this should use it instead
+  def self.organization_students(organization)
+    joins(awarded_points: :course)
+      .where(courses: { organization_id: organization.id })
+      .group('users.id')
+  end
+
   def self.course_sheet_students(course, sheetname)
     AwardedPoint.users_in_course_with_sheet(course, sheetname)
   end

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -73,9 +73,9 @@
     <%= link_to 'Edit organization', edit_organization_path(@organization) %>
 <% end %>
 
-<% if can? :view, :participants_list %>
+<% if can? :view_participant_list, @organization%>
     <br/>
-    <%= link_to 'List of registered users', participants_path %>
+    <%= link_to 'List of registered users', organization_participants_path(@organization) %>
 <% end %>
 
 <% if can? :teach, @organization %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ resources :organizations, except: :destory, path: 'org' do
       get 'list_requests'
     end
 
+    resources :participants, only: [:index]
+
     resources :teachers, only: [:index, :create, :destroy]
 
     get 'course_templates', to: 'course_templates#list_for_teachers'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,6 +47,21 @@ describe User, type: :model do
       expect(a).to include(@user2)
     end
 
+    it 'organization_students' do
+      organization1 = FactoryGirl.create :accepted_organization, slug: 'slug1'
+      organization2 = FactoryGirl.create :accepted_organization, slug: 'slug2'
+      @course1.update(organization: organization1)
+      @course2.update(organization: organization2)
+
+      a = User.organization_students(organization1)
+      expect(a.length).to eq(1)
+      expect(a).to include(@user1)
+
+      a = User.organization_students(organization2)
+      expect(a.length).to eq(1)
+      expect(a).to include(@user2)
+    end
+
     it 'course_sheet_students' do
       a = User.course_sheet_students(@course1, 's1')
       expect(a.length).to eq(1)


### PR DESCRIPTION
Participant index now supports organization too, list only student/courses for the organization, if it's given in path.

So /org/hy/participants/ should work now. This was needed from some external scoring system, asked by @josalmi 