### PR TITLE
Run all tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 sudo: true
 
+env:
+  - RSPEC_PATTERN="spec/{controllers,features,helpers,lib,mailers,models,usermanual}/**/*.rb"
+  - RSPEC_PATTERN="spec/integration/{running_tests,comet,feedback,requests}/**/*.rb"
+  - RSPEC_PATTERN="spec/integration/*.rb"
+
 language: ruby
 rvm:
   - 2.2.0
@@ -7,19 +12,34 @@ rvm:
 git:
   submodules: false
 
+addons:
+  apt:
+    packages:
+      - valgrind
+      - check
+      - pkg-config
+      - gcc
+
 before_install:
-  - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
-  - git submodule update --init --recursive
-  - git config --global user.email "travis@example.com"
-  - git config --global user.name "Travis"
+  - . ./setup-travis.sh
+
+install:
+  - bundle install --retry=3 --jobs=3 --deployment
 
 services:
   - postgresql
 
 before_script:
   - createuser -U postgres -s tmc
+  - bundle exec rake db:reset
 
 script:
-  - bundle exec rake db:reset
-  - export rvmsudo_secure_path=1
-  - rvmsudo bundle exec rake spec SPEC="spec/controllers spec/models spec/helpers spec/mailers"
+  - ./ext/tmc-sandbox/web/webapp.rb start
+  - bundle exec rake spec SPEC_OPTS="--pattern $RSPEC_PATTERN --tag ~network -f d" SANDBOX_HOST=127.0.0.1 SANDBOX_PORT=3001
+
+after_failure:
+  - cat ext/tmc-sandbox/web/log/*
+
+notifications:
+  slack:
+    secure: YCiWybZYBoJ2JDjpPp5Idf4OvqScay5WfEuQMdvee42kgsSVolew6V5YUx41E29Of+2xAcQ+be5XImzO7SlTYuaGD6hf0JZvjjxO3gpycCljNSvDgFnBF9s4WuUQ31LozI6eQqo/9c5zUFxW9MGeeaRUWvurlW0rRHM3UKokAQk=

--- a/lib/maven_project.rb
+++ b/lib/maven_project.rb
@@ -58,7 +58,7 @@ class MavenProject
 
   def compile!
     Dir.chdir(path) do
-      SystemCommands.sh!('mvn -q package -Dmaven.test.skip=true', {escape: false})
+      SystemCommands.sh!('mvn', '-q', 'package', '-Dmaven.test.skip=true')
     end
   end
 

--- a/lib/maven_project.rb
+++ b/lib/maven_project.rb
@@ -58,7 +58,7 @@ class MavenProject
 
   def compile!
     Dir.chdir(path) do
-      SystemCommands.sh!('mvn', '-q', 'package')
+      SystemCommands.sh!('mvn -q package -Dmaven.test.skip=true', {escape: false})
     end
   end
 

--- a/lib/tasks/travis.rake
+++ b/lib/tasks/travis.rake
@@ -1,0 +1,15 @@
+require 'system_commands'
+
+namespace :travis do
+  desc "Update vendor/bundle files to gem cache on tmc-server"
+  task :gemcache do
+    unless Dir.exists? 'vendor/bundle'
+      puts 'No vendor/bundle exists, create it with `bundle install --path vendor/bundle`'
+      exit 1
+    end
+    puts "Pushing new gems from local gem cache (vendor/bundle) to travis cache"
+    SystemCommands.sh!("find vendor/bundle -iname '*.gem'  -print0  | rsync -0 --checksum -avz  --files-from=- . web01.testmycode.net:/srv/www/testmycode.net/travis/rubygems-cache/", {escape: false})
+    puts "Done"
+  end
+end
+

--- a/lib/tmc_comet.rb
+++ b/lib/tmc_comet.rb
@@ -16,7 +16,7 @@ class TmcComet < MavenProject
     # This needs to be mvn install'ed as opposed to merely packaged because
     # the WAR file is loaded dynamically.
     Dir.chdir(path.parent) do
-      SystemCommands.sh!('mvn', '-q', 'install')
+      SystemCommands.sh!('mvn -q install -Dmaven.test.skip=true', {escape: false})
     end
   end
 

--- a/lib/tmc_comet.rb
+++ b/lib/tmc_comet.rb
@@ -16,7 +16,7 @@ class TmcComet < MavenProject
     # This needs to be mvn install'ed as opposed to merely packaged because
     # the WAR file is loaded dynamically.
     Dir.chdir(path.parent) do
-      SystemCommands.sh!('mvn -q install -Dmaven.test.skip=true', {escape: false})
+      SystemCommands.sh!('mvn', '-q', 'install', '-Dmaven.test.skip=true')
     end
   end
 

--- a/setup-travis.sh
+++ b/setup-travis.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Sets up dependencies and environment for tests to be run in Travis.
+#
+# This is not recommended to be run locally, and it employs some hacks and tricks to get by limitations of travis.
+
+set -ev
+
+# Unset bundle Gemfile, since we have multiple projects with separate Gemfiles and it will just cause confusion
+unset BUNDLE_GEMFILE
+
+# Update bundler
+gem update --system
+gem --version
+
+# Cache file containing vendor/bundle/cache - to speed up bundle install and to fix possible connection timeouts to Rubygems
+wget -r -q -nH --cut-dirs=2 --no-parent -A gem  http://testmycode.net/travis/rubygems-cache/vendor/
+bundle install --retry=3 --jobs=3 --deployment
+
+# Git settings so that Travis can clone submodules
+sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+git submodule update --init --recursive
+git config --global user.email "travis@example.com"
+git config --global user.name "Travis"
+
+# Install tmc-check
+export CHECK_INSTALL_DIR=$HOME/check
+mkdir $CHECK_INSTALL_DIR
+git clone https://github.com/testmycode/tmc-check.git
+cd tmc-check
+bundle install --jobs=3 --retry=3 --deployment
+make
+make install PREFIX=$CHECK_INSTALL_DIR
+export PATH="$CHECK_INSTALL_DIR/bin:$PATH"
+cd ..
+export LD_LIBRARY_PATH=$CHECK_INSTALL_DIR/lib:/lib:/usr/lib:/usr/local/lib:$LD_LIBRARY_PATH
+export C_INCLUDE_PATH=$CHECK_INSTALL_DIR/include:$C_INCLUDE_PATH
+export PKG_CONFIG_PATH=$CHECK_INSTALL_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
+
+# Reduce mavens memory usage
+export MAVEN_OPTS="-Xms512m -Xmx1024m -XX:PermSize=1024m"
+
+# Build submodules except sandbox
+bundle exec rake compile
+
+# Use pre built tmc-sandbox
+wget -qO- http://testmycode.net/travis/sandbox-$(git submodule status ext/tmc-sandbox | grep -E -o  "[0-9a-f]{40}").tar.gz | tar xvz -C ext/
+cd ext/tmc-sandbox/web
+# Set current user and reduce max instances, though only one instance will be used at any given time
+sed -i "s/\(tmc_user: \)tmc/\1 $(whoami)/" site.defaults.yml
+sed -i "s/\(tmc_group: \)tmc/\1 $(whoami)/" site.defaults.yml
+sed -i 's/\(max_instances: \)[0-9]*/\12/' site.defaults.yml
+# Disable network
+sed -i '/^network:$/{$!{N;s/^\(network:\)\n\(  enabled: \)true$/\1\n\2false/;ty;P;D;:y}}' site.defaults.yml
+cat site.defaults.yml
+bundle install --retry=3 --jobs=3
+rake ext
+cd ../../../

--- a/spec/integration/running_tests/maven_tests_spec.rb
+++ b/spec/integration/running_tests/maven_tests_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe RemoteSandboxForTesting, type: :request, integration: true do
+describe RemoteSandboxForTesting, type: :request, integration: true, network: true do
   specify 'running maven tests' do
     setup = SubmissionTestSetup.new(exercise_name: 'MavenExercise')
     submission = setup.submission


### PR DESCRIPTION
Run all* tests in travis with real sandbox.

We cannot use the container based setup, not beause we need sudo, which we don't, but because sandbox caused error `/dev/shm/ must be not mounted noexec`.

We also split running tests under three builds to gain reasonable test run speed, and it lets us to avoid the time limit of 50min for each task.

The build script does caching for bundler manually, maybe too manually but I'd leave it as it is for now.


* one test (the only maven on sandbox) is not being run, since to use maven it would require network access to download dependencies and use of tap devices is not possible in travis...