### PR TITLE
Api find course by name or id

### DIFF
--- a/app/controllers/api/v8/apidocs_controller.rb
+++ b/app/controllers/api/v8/apidocs_controller.rb
@@ -4,7 +4,7 @@ class Api::V8::ApidocsController < ActionController::Base
   swagger_root do
     key :swagger, "2.0"
     info do
-      key :version, "1.0.0"
+      key :version, "8"
       key :title, "TMC API documentation"
       key :description, "TMC API documentation"
       contact do
@@ -32,6 +32,13 @@ class Api::V8::ApidocsController < ActionController::Base
       key :description, "Course's id"
       key :required, true
       key :type, :integer
+    end
+    parameter :path_course_name do
+      key :name, :course_name
+      key :in, :path
+      key :description, "Course's name"
+      key :required, true
+      key :type, :string
     end
     parameter :path_exercise_id do
       key :name, :exercise_id

--- a/app/controllers/api/v8/apidocs_controller.rb
+++ b/app/controllers/api/v8/apidocs_controller.rb
@@ -67,7 +67,7 @@ class Api::V8::ApidocsController < ActionController::Base
   SWAGGERED_CLASSES = [
       CoursesController,
       Course,
-    self,
+      self,
   ].freeze
 
   def index

--- a/app/controllers/api/v8/apidocs_controller.rb
+++ b/app/controllers/api/v8/apidocs_controller.rb
@@ -65,7 +65,7 @@ class Api::V8::ApidocsController < ActionController::Base
 
   # A list of all classes that have swagger_* declarations.
   SWAGGERED_CLASSES = [
-      CoursesController,
+      Api::V8::CoursesController,
       Course,
       self,
   ].freeze

--- a/app/controllers/api/v8/apidocs_controller.rb
+++ b/app/controllers/api/v8/apidocs_controller.rb
@@ -65,6 +65,8 @@ class Api::V8::ApidocsController < ActionController::Base
 
   # A list of all classes that have swagger_* declarations.
   SWAGGERED_CLASSES = [
+      CoursesController,
+      Course,
     self,
   ].freeze
 

--- a/app/controllers/api/v8/courses_controller.rb
+++ b/app/controllers/api/v8/courses_controller.rb
@@ -59,7 +59,7 @@ class Api::V8::CoursesController < Api::V8::BaseController
 
   def show_json(course)
     authorize! :read, course
-    return respond_access_denied('Authentication required') if current_user.guest?
+    unauthorized_guest! if current_user.guest?
     present(course)
   end
 end

--- a/app/controllers/api/v8/courses_controller.rb
+++ b/app/controllers/api/v8/courses_controller.rb
@@ -2,48 +2,49 @@ class Api::V8::CoursesController < Api::V8::BaseController
 
   include Swagger::Blocks
 
-  swagger_path '/api/v8/courses/{course_id}' do
+  swagger_path "/api/v8/courses/{course_id}" do
     operation :get do
-      key :description, 'Returns the course\'s information in a json format. Course is searched by id'
-      key :operationId, 'getCourseById'
-      key :produces, ['application/json']
-      key :tags, ['course']
-      parameter '$ref': '#/parameters/path_course_id'
-      response 403, '$ref': '#/responses/error'
-      response 404, '$ref': '#/responses/error'
+      key :description, "Returns the course's information in a json format. Course is searched by id"
+      key :operationId, "getCourseById"
+      key :produces, ["application/json"]
+      key :tags, ["course"]
+      parameter "$ref": "#/parameters/path_course_id"
+      response 403, "$ref": "#/responses/error"
+      response 404, "$ref": "#/responses/error"
       response 200 do
-        key :description, 'Course in json'
+        key :description, "Course in json"
         schema do
           key :title, :course
           key :required, [:course]
-          property :course, '$ref': :Course
+          property :course, "$ref": :Course
         end
       end
     end
   end
 
-  swagger_path '/api/v8/organizations/{organization_id}/courses/{course_name}' do
+  swagger_path "/api/v8/organizations/{organization_id}/courses/{course_name}" do
     operation :get do
-      key :description, 'Returns the course\'s information in a json format. Course is searched by organization id and course name'
-      key :operationId, 'getCourseByOrganizationIdAndCourseName'
-      key :produces, ['application/json']
-      key :tags, ['course']
-      parameter '$ref': '#/parameters/path_organization_id'
-      parameter '$ref': '#/parameters/path_course_name'
-      response 403, '$ref': '#/responses/error'
-      response 404, '$ref': '#/responses/error'
+      key :description, "Returns the course's information in a json format. Course is searched by organization id and course name"
+      key :operationId, "getCourseByOrganizationIdAndCourseName"
+      key :produces, ["application/json"]
+      key :tags, ["course"]
+      parameter "$ref": "#/parameters/path_organization_id"
+      parameter "$ref": "#/parameters/path_course_name"
+      response 403, "$ref": "#/responses/error"
+      response 404, "$ref": "#/responses/error"
       response 200 do
-        key :description, 'Course in json'
+        key :description, "Course in json"
         schema do
           key :title, :course
           key :required, [:course]
-          property :course, '$ref': :Course
+          property :course, "$ref": :Course
         end
       end
     end
   end
 
   def find_by_name
+    unauthorized_guest! if current_user.guest?
     course_name = "#{params[:slug]}-#{params[:name]}"
     course = Course.find_by(name: course_name)
     raise ActiveRecord::RecordNotFound, "Couldn't find Course with name #{course_name}" unless course
@@ -51,6 +52,7 @@ class Api::V8::CoursesController < Api::V8::BaseController
   end
 
   def find_by_id
+    unauthorized_guest! if current_user.guest?
     course_id = params[:id]
     course = Course.find_by_id(course_id)
     raise ActiveRecord::RecordNotFound, "Couldn't find Course with id #{course_id}" unless course
@@ -59,7 +61,6 @@ class Api::V8::CoursesController < Api::V8::BaseController
 
   def show_json(course)
     authorize! :read, course
-    unauthorized_guest! if current_user.guest?
     present(course)
   end
 end

--- a/app/controllers/api/v8/courses_controller.rb
+++ b/app/controllers/api/v8/courses_controller.rb
@@ -1,0 +1,7 @@
+
+class Api::V8::CoursesController < Api::V8::BaseController
+  def show_json
+    course = params[:id] && Course.find(params[:id]) || Course.find_by(name: "#{params[:slug]}-#{params[:name]}")
+    present(course)
+  end
+end

--- a/app/controllers/api/v8/courses_controller.rb
+++ b/app/controllers/api/v8/courses_controller.rb
@@ -1,7 +1,65 @@
-
 class Api::V8::CoursesController < Api::V8::BaseController
-  def show_json
-    course = params[:id] && Course.find(params[:id]) || Course.find_by(name: "#{params[:slug]}-#{params[:name]}")
+
+  include Swagger::Blocks
+
+  swagger_path '/api/v8/courses/{course_id}' do
+    operation :get do
+      key :description, 'Returns the course\'s information in a json format. Course is searched by id'
+      key :operationId, 'getCourseById'
+      key :produces, ['application/json']
+      key :tags, ['course']
+      parameter '$ref': '#/parameters/path_course_id'
+      response 403, '$ref': '#/responses/error'
+      response 404, '$ref': '#/responses/error'
+      response 200 do
+        key :description, 'Course in json'
+        schema do
+          key :title, :course
+          key :required, [:course]
+          property :course, '$ref': :Course
+        end
+      end
+    end
+  end
+
+  swagger_path '/api/v8/organizations/{organization_id}/courses/{course_name}' do
+    operation :get do
+      key :description, 'Returns the course\'s information in a json format. Course is searched by organization id and course name'
+      key :operationId, 'getCourseByOrganizationIdAndCourseName'
+      key :produces, ['application/json']
+      key :tags, ['course']
+      parameter '$ref': '#/parameters/path_organization_id'
+      parameter '$ref': '#/parameters/path_course_name'
+      response 403, '$ref': '#/responses/error'
+      response 404, '$ref': '#/responses/error'
+      response 200 do
+        key :description, 'Course in json'
+        schema do
+          key :title, :course
+          key :required, [:course]
+          property :course, '$ref': :Course
+        end
+      end
+    end
+  end
+
+  def find_by_name
+    course_name = "#{params[:slug]}-#{params[:name]}"
+    course = Course.find_by(name: course_name)
+    raise ActiveRecord::RecordNotFound, "Couldn't find Course with name #{course_name}" unless course
+    show_json(course)
+  end
+
+  def find_by_id
+    course_id = params[:id]
+    course = Course.find_by_id(course_id)
+    raise ActiveRecord::RecordNotFound, "Couldn't find Course with id #{course_id}" unless course
+    show_json(course)
+  end
+
+  def show_json(course)
+    authorize! :read, course
+    return respond_access_denied('Authentication required') if current_user.guest?
     present(course)
   end
 end

--- a/app/controllers/api/v8/courses_controller.rb
+++ b/app/controllers/api/v8/courses_controller.rb
@@ -61,6 +61,6 @@ class Api::V8::CoursesController < Api::V8::BaseController
 
   def show_json(course)
     authorize! :read, course
-    present(course)
+    render json: course, except: [:created_at, :updated_at]
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -112,12 +112,12 @@ class ApplicationController < ActionController::Base
     @action_name = action_name
   end
 
-  def unauthorized!(message = "Unauthorized access")
-    raise CanCan::AccessDenied.new(message: message)
+  def unauthorized!(message = nil)
+    raise CanCan::AccessDenied.new(message)
   end
 
   def unauthorized_guest!(message = "Authentication required")
-    unauthorized!(message: message)
+    unauthorized!(message)
   end
 
   def respond_not_found(msg = 'Not Found')

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -112,6 +112,14 @@ class ApplicationController < ActionController::Base
     @action_name = action_name
   end
 
+  def unauthorized!(message = "Unauthorized access")
+    raise CanCan::AccessDenied.new(message: message)
+  end
+
+  def unauthorized_guest!(message = "Authentication required")
+    unauthorized!(message: message)
+  end
+
   def respond_not_found(msg = 'Not Found')
     respond_with_error(msg, 404)
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -524,5 +524,4 @@ class Course < ActiveRecord::Base
       errors.add(:external_scoreboard_url, 'contains invalid keys')
     end
   end
-
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -5,6 +5,7 @@ require 'date_and_time_utils'
 
 class Course < ActiveRecord::Base
   include SystemCommands
+  include Swagger::Blocks
 
   self.include_root_in_json = false
 
@@ -473,4 +474,55 @@ class Course < ActiveRecord::Base
       errors.add(:external_scoreboard_url, 'contains invalid keys')
     end
   end
+
+  swagger_schema :Course do
+    key :required, [
+        :name,
+        :created_at,
+        :updated_at,
+        :hide_after,
+        :hidden,
+        :cache_version,
+        :spreadsheet_key,
+        :hidden_if_registered_after,
+        :refreshed_at,
+        :locked_exercise_points_visible,
+        :description,
+        :paste_visibility,
+        :formal_name,
+        :certificate_downloadable,
+        :certificate_unlock_spec,
+        :organization_id,
+        :disabled_status,
+        :title,
+        :material_url,
+        :course_template_id,
+        :external_scoreboard_url,
+        :hide_submission_results,
+    ]
+
+    property :name, type: :string, example: "courseid-coursename"
+    property :created_at, type: :string, example: "2016-10-10T13:22:19.554+03:00"
+    property :updated_at, type: :string, example: "2016-10-10T13:22:19.554+03:00"
+    property :hide_after, type: :string, example: "2016-10-10T13:22:19.554+03:00"
+    property :hidden, type: :boolean, example: false
+    property :cache_version, type: :integer, example: 1
+    property :spreadsheet_key, type: :string
+    property :hidden_if_registered_after, type: :string
+    property :refreshed_at, type: :string
+    property :locked_exercise_points_visible, type: :boolean
+    property :description, type: :string
+    property :paste_visibility, type: :string
+    property :formal_name, type: :string
+    property :certificate_downloadable, type: :boolean
+    property :certificate_unlock_spec, type: :string
+    property :organization_id, type: :integer
+    property :disabled_status, type: :integer
+    property :title, type: :string
+    property :material_url, type: :string
+    property :course_template_id, type: :integer
+    property :external_scoreboard_url, type: :string
+    property :hide_submission_results, type: :boolean
+  end
+
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -10,8 +10,6 @@ class Course < ActiveRecord::Base
   swagger_schema :Course do
     key :required, [
         :name,
-        :created_at,
-        :updated_at,
         :hide_after,
         :hidden,
         :cache_version,
@@ -34,8 +32,6 @@ class Course < ActiveRecord::Base
     ]
 
     property :name, type: :string, example: "courseid-coursename"
-    property :created_at, type: :string, example: "2016-10-10T13:22:19.554+03:00"
-    property :updated_at, type: :string, example: "2016-10-10T13:22:19.554+03:00"
     property :hide_after, type: :string, example: "2016-10-10T13:22:19.554+03:00"
     property :hidden, type: :boolean, example: false
     property :cache_version, type: :integer, example: 1

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -7,6 +7,56 @@ class Course < ActiveRecord::Base
   include SystemCommands
   include Swagger::Blocks
 
+  swagger_schema :Course do
+    key :required, [
+        :name,
+        :created_at,
+        :updated_at,
+        :hide_after,
+        :hidden,
+        :cache_version,
+        :spreadsheet_key,
+        :hidden_if_registered_after,
+        :refreshed_at,
+        :locked_exercise_points_visible,
+        :description,
+        :paste_visibility,
+        :formal_name,
+        :certificate_downloadable,
+        :certificate_unlock_spec,
+        :organization_id,
+        :disabled_status,
+        :title,
+        :material_url,
+        :course_template_id,
+        :external_scoreboard_url,
+        :hide_submission_results,
+    ]
+
+    property :name, type: :string, example: "courseid-coursename"
+    property :created_at, type: :string, example: "2016-10-10T13:22:19.554+03:00"
+    property :updated_at, type: :string, example: "2016-10-10T13:22:19.554+03:00"
+    property :hide_after, type: :string, example: "2016-10-10T13:22:19.554+03:00"
+    property :hidden, type: :boolean, example: false
+    property :cache_version, type: :integer, example: 1
+    property :spreadsheet_key, type: :string
+    property :hidden_if_registered_after, type: :string
+    property :refreshed_at, type: :string
+    property :locked_exercise_points_visible, type: :boolean
+    property :description, type: :string
+    property :paste_visibility, type: :string
+    property :formal_name, type: :string
+    property :certificate_downloadable, type: :boolean
+    property :certificate_unlock_spec, type: :string
+    property :organization_id, type: :integer
+    property :disabled_status, type: :integer
+    property :title, type: :string
+    property :material_url, type: :string
+    property :course_template_id, type: :integer
+    property :external_scoreboard_url, type: :string
+    property :hide_submission_results, type: :boolean
+  end
+
   self.include_root_in_json = false
 
   validates :name,
@@ -473,56 +523,6 @@ class Course < ActiveRecord::Base
     rescue
       errors.add(:external_scoreboard_url, 'contains invalid keys')
     end
-  end
-
-  swagger_schema :Course do
-    key :required, [
-        :name,
-        :created_at,
-        :updated_at,
-        :hide_after,
-        :hidden,
-        :cache_version,
-        :spreadsheet_key,
-        :hidden_if_registered_after,
-        :refreshed_at,
-        :locked_exercise_points_visible,
-        :description,
-        :paste_visibility,
-        :formal_name,
-        :certificate_downloadable,
-        :certificate_unlock_spec,
-        :organization_id,
-        :disabled_status,
-        :title,
-        :material_url,
-        :course_template_id,
-        :external_scoreboard_url,
-        :hide_submission_results,
-    ]
-
-    property :name, type: :string, example: "courseid-coursename"
-    property :created_at, type: :string, example: "2016-10-10T13:22:19.554+03:00"
-    property :updated_at, type: :string, example: "2016-10-10T13:22:19.554+03:00"
-    property :hide_after, type: :string, example: "2016-10-10T13:22:19.554+03:00"
-    property :hidden, type: :boolean, example: false
-    property :cache_version, type: :integer, example: 1
-    property :spreadsheet_key, type: :string
-    property :hidden_if_registered_after, type: :string
-    property :refreshed_at, type: :string
-    property :locked_exercise_points_visible, type: :boolean
-    property :description, type: :string
-    property :paste_visibility, type: :string
-    property :formal_name, type: :string
-    property :certificate_downloadable, type: :boolean
-    property :certificate_unlock_spec, type: :string
-    property :organization_id, type: :integer
-    property :disabled_status, type: :integer
-    property :title, type: :string
-    property :material_url, type: :string
-    property :course_template_id, type: :integer
-    property :external_scoreboard_url, type: :string
-    property :hide_submission_results, type: :boolean
   end
 
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -29,8 +29,8 @@ class Course < ActiveRecord::Base
         :title,
         :material_url,
         :course_template_id,
-        :external_scoreboard_url,
         :hide_submission_results,
+        :external_scoreboard_url,
     ]
 
     property :name, type: :string, example: "courseid-coursename"
@@ -41,20 +41,20 @@ class Course < ActiveRecord::Base
     property :cache_version, type: :integer, example: 1
     property :spreadsheet_key, type: :string
     property :hidden_if_registered_after, type: :string
-    property :refreshed_at, type: :string
-    property :locked_exercise_points_visible, type: :boolean
-    property :description, type: :string
+    property :refreshed_at, type: :string, example: "2016-10-10T13:22:36.871+03:00"
+    property :locked_exercise_points_visible, type: :boolean, example: true
+    property :description, type: :string, example: ""
     property :paste_visibility, type: :string
     property :formal_name, type: :string
-    property :certificate_downloadable, type: :boolean
+    property :certificate_downloadable, type: :boolean, example: false
     property :certificate_unlock_spec, type: :string
-    property :organization_id, type: :integer
-    property :disabled_status, type: :integer
-    property :title, type: :string
-    property :material_url, type: :string
-    property :course_template_id, type: :integer
+    property :organization_id, type: :integer, example: 1
+    property :disabled_status, type: :string, example: "enabled"
+    property :title, type: :string, example: "testcourse"
+    property :material_url, type: :string, example: ""
+    property :course_template_id, type: :integer, example: 1
+    property :hide_submission_results, type: :boolean, example: false
     property :external_scoreboard_url, type: :string
-    property :hide_submission_results, type: :boolean
   end
 
   self.include_root_in_json = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,14 +45,14 @@ TmcServer::Application.routes.draw do
         scope '/:slug' do
           scope '/courses' do
             scope '/:name' do
-              get '/' => 'courses#show_json'
+              get '/' => 'courses#find_by_name'
             end
           end
         end
       end
       scope '/courses' do
         scope '/:id' do
-          get '/' => 'courses#show_json'
+          get '/' => 'courses#find_by_id'
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,20 @@ TmcServer::Application.routes.draw do
 
     namespace :v8, defaults: { format: 'json' } do
       get '/documentation', to: 'apidocs#index'
+      scope '/organizations' do
+        scope '/:slug' do
+          scope '/courses' do
+            scope '/:name' do
+              get '/' => 'courses#show'
+            end
+          end
+        end
+      end
+      scope '/courses' do
+        scope '/:id' do
+          get '/' => 'courses#show_json'
+        end
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ TmcServer::Application.routes.draw do
         scope '/:slug' do
           scope '/courses' do
             scope '/:name' do
-              get '/' => 'courses#show'
+              get '/' => 'courses#show_json'
             end
           end
         end

--- a/spec/controllers/api/v8/courses_controller_spec.rb
+++ b/spec/controllers/api/v8/courses_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Api::V8::CoursesController, type: :controller do
   let!(:organization) { FactoryGirl.create(:organization) }
@@ -11,20 +11,20 @@ describe Api::V8::CoursesController, type: :controller do
     controller.stub(:doorkeeper_token) { token }
   end
 
-  describe 'GET find_by_id' do
+  describe "GET find_by_id" do
 
-    describe 'when logged as admin' do
+    describe "as admin" do
       let(:token) { double resource_owner_id: admin.id, acceptable?: true }
 
-      describe 'when course ID given' do
-        it 'shows course information' do
+      describe "when course ID given" do
+        it "shows course information" do
           get :find_by_id, id: course.id
           expect(response).to have_http_status(:success)
           expect(response.body).to have_content course.name
         end
       end
       describe "when hidden course's ID given" do
-        it 'shows course information' do
+        it "shows course information" do
           course.hidden = true
           course.save!
           get :find_by_id, id: course.id
@@ -32,8 +32,8 @@ describe Api::V8::CoursesController, type: :controller do
           expect(response.body).to have_content course.name
         end
       end
-      describe 'when invalid course ID given' do
-        it 'shows error' do
+      describe "when invalid course ID given" do
+        it "shows error about finding course" do
           get :find_by_id, id: -1
           expect(response).to have_http_status(:missing)
           expect(response.body).to have_content "Couldn't find Course"
@@ -41,18 +41,18 @@ describe Api::V8::CoursesController, type: :controller do
       end
     end
 
-    describe 'when logged as user' do
+    describe "as user" do
       let(:token) { double resource_owner_id: user.id, acceptable?: true }
 
-      describe 'when course ID given' do
-        it 'shows course information' do
+      describe "when course ID given" do
+        it "shows course information" do
           get :find_by_id, id: course.id
           expect(response).to have_http_status(:success)
           expect(response.body).to have_content course.name
         end
       end
       describe "when hidden course's ID given" do
-        it 'returns authorization error' do
+        it "shows authorization error" do
           course.hidden = true
           course.save!
           get :find_by_id, id: course.id
@@ -60,8 +60,8 @@ describe Api::V8::CoursesController, type: :controller do
           expect(response.body).to have_content "You are not authorized"
         end
       end
-      describe 'when invalid course ID given' do
-        it 'shows error' do
+      describe "when invalid course ID given" do
+        it "shows error about finding course" do
           get :find_by_id, id: -1
           expect(response).to have_http_status(:missing)
           expect(response.body).to have_content "Couldn't find Course"
@@ -69,50 +69,50 @@ describe Api::V8::CoursesController, type: :controller do
       end
     end
 
-    describe 'as guest' do
-      let(:token) { double resource_owner_id: user.id, acceptable?: true }
+    describe "as guest" do
+      let(:token) { nil }
 
-      describe 'when course ID given' do
-        it 'returns authorization error' do
+      describe "when course ID given" do
+        it "shows authentication error" do
           get :find_by_id, id: course.id
-          expect(response).to have_http_status(:success)
-          expect(response.body).to have_content course.name
+          expect(response).to have_http_status(403)
+          expect(response.body).to have_content "Authentication required"
         end
       end
       describe "when hidden course's ID given" do
-        it 'returns authorization error' do
+        it "shows authentication error" do
           course.hidden = true
           course.save!
           get :find_by_id, id: course.id
           expect(response).to have_http_status(403)
-          expect(response.body).to have_content "You are not authorized"
+          expect(response.body).to have_content "Authentication required"
         end
       end
-      describe 'when invalid course ID given' do
-        it 'shows error' do
+      describe "when invalid course ID given" do
+        it "shows authentication error" do
           get :find_by_id, id: -1
-          expect(response).to have_http_status(:missing)
-          expect(response.body).to have_content "Couldn't find Course"
+          expect(response).to have_http_status(403)
+          expect(response.body).to have_content "Authentication required"
         end
       end
     end
 
   end
 
-  describe 'GET find_by_id' do
+  describe "GET find_by_id" do
 
-    describe 'when logged as admin' do
+    describe "when logged as admin" do
       let(:token) { double resource_owner_id: admin.id, acceptable?: true }
 
-      describe 'when organization id and course name given' do
-        it 'shows course information' do
+      describe "when organization id and course name given" do
+        it "shows course information" do
           get :find_by_name, {slug: organization.slug, name: course_name}
           expect(response).to have_http_status(:success)
           expect(response.body).to have_content course.name
         end
       end
       describe "when hidden course's organization id and course name given" do
-        it 'shows course information' do
+        it "shows course information" do
           course.hidden = true
           course.save!
           get :find_by_name, {slug: organization.slug, name: course_name}
@@ -121,33 +121,40 @@ describe Api::V8::CoursesController, type: :controller do
         end
       end
       describe "when invalid organization id and valid course name given" do
-        it 'shows error' do
+        it "error about finding course" do
           get :find_by_name, {slug: "bad", name: course_name}
           expect(response).to have_http_status(:missing)
           expect(response.body).to have_content "Couldn't find Course"
         end
       end
       describe "when valid organization id and invalid course name given" do
-        it 'shows error' do
+        it "error about finding course" do
           get :find_by_name, {slug: organization.slug, name: "bad"}
+          expect(response).to have_http_status(:missing)
+          expect(response.body).to have_content "Couldn't find Course"
+        end
+      end
+      describe "when invalidvalid organization id and invalid course name given" do
+        it "error about finding course" do
+          get :find_by_name, {slug: "bad", name: "bad"}
           expect(response).to have_http_status(:missing)
           expect(response.body).to have_content "Couldn't find Course"
         end
       end
     end
 
-    describe 'when logged as user' do
+    describe "when logged as user" do
       let(:token) { double resource_owner_id: user.id, acceptable?: true }
 
-      describe 'when organization id and course name given' do
-        it 'shows course information' do
+      describe "when organization id and course name given" do
+        it "shows course information" do
           get :find_by_name, {slug: organization.slug, name: course_name}
           expect(response).to have_http_status(:success)
           expect(response.body).to have_content course.name
         end
       end
       describe "when hidden course's organization id and course name given" do
-        it 'shows course information' do
+        it "shows authorization error" do
           course.hidden = true
           course.save!
           get :find_by_name, {slug: organization.slug, name: course_name}
@@ -156,14 +163,14 @@ describe Api::V8::CoursesController, type: :controller do
         end
       end
       describe "when invalid organization id and valid course name given" do
-        it 'shows error' do
+        it "shows error about finding course" do
           get :find_by_name, {slug: "bad", name: course_name}
           expect(response).to have_http_status(:missing)
           expect(response.body).to have_content "Couldn't find Course"
         end
       end
       describe "when valid organization id and invalid course name given" do
-        it 'shows error' do
+        it "error about finding course" do
           get :find_by_name, {slug: organization.slug, name: "bad"}
           expect(response).to have_http_status(:missing)
           expect(response.body).to have_content "Couldn't find Course"
@@ -171,37 +178,37 @@ describe Api::V8::CoursesController, type: :controller do
       end
     end
 
-    describe 'as guest' do
+    describe "as guest" do
       let(:token) { nil }
 
-      describe 'when organization id and course name given' do
-        it 'shows course information' do
+      describe "when organization id and course name given" do
+        it "shows authentication error" do
           get :find_by_name, {slug: organization.slug, name: course_name}
           expect(response).to have_http_status(403)
           expect(response.body).to have_content "Authentication required"
         end
       end
       describe "when hidden course's organization id and course name given" do
-        it 'shows course information' do
+        it "shows authentication error" do
           course.hidden = true
           course.save!
           get :find_by_name, {slug: organization.slug, name: course_name}
           expect(response).to have_http_status(403)
-          expect(response.body).to have_content "You are not authorized"
+          expect(response.body).to have_content "Authentication required"
         end
       end
       describe "when invalid organization id and valid course name given" do
-        it 'shows error' do
+        it "shows authentication error" do
           get :find_by_name, {slug: "bad", name: course_name}
-          expect(response).to have_http_status(:missing)
-          expect(response.body).to have_content "Couldn't find Course"
+          expect(response).to have_http_status(403)
+          expect(response.body).to have_content "Authentication required"
         end
       end
       describe "when valid organization id and invalid course name given" do
-        it 'shows error' do
+        it "shows authentication error" do
           get :find_by_name, {slug: organization.slug, name: "bad"}
-          expect(response).to have_http_status(:missing)
-          expect(response.body).to have_content "Couldn't find Course"
+          expect(response).to have_http_status(403)
+          expect(response.body).to have_content "Authentication required"
         end
       end
     end

--- a/spec/controllers/api/v8/courses_controller_spec.rb
+++ b/spec/controllers/api/v8/courses_controller_spec.rb
@@ -1,0 +1,209 @@
+require 'spec_helper'
+
+describe Api::V8::CoursesController, type: :controller do
+  let!(:organization) { FactoryGirl.create(:organization) }
+  let!(:course_name) { "testcourse" }
+  let!(:course) { FactoryGirl.create(:course, name: "#{organization.slug}-#{course_name}") }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:admin) { FactoryGirl.create(:admin) }
+
+  before(:each) do
+    controller.stub(:doorkeeper_token) { token }
+  end
+
+  describe 'GET find_by_id' do
+
+    describe 'when logged as admin' do
+      let(:token) { double resource_owner_id: admin.id, acceptable?: true }
+
+      describe 'when course ID given' do
+        it 'shows course information' do
+          get :find_by_id, id: course.id
+          expect(response).to have_http_status(:success)
+          expect(response.body).to have_content course.name
+        end
+      end
+      describe "when hidden course's ID given" do
+        it 'shows course information' do
+          course.hidden = true
+          course.save!
+          get :find_by_id, id: course.id
+          expect(response).to have_http_status(:success)
+          expect(response.body).to have_content course.name
+        end
+      end
+      describe 'when invalid course ID given' do
+        it 'shows error' do
+          get :find_by_id, id: -1
+          expect(response).to have_http_status(:missing)
+          expect(response.body).to have_content "Couldn't find Course"
+        end
+      end
+    end
+
+    describe 'when logged as user' do
+      let(:token) { double resource_owner_id: user.id, acceptable?: true }
+
+      describe 'when course ID given' do
+        it 'shows course information' do
+          get :find_by_id, id: course.id
+          expect(response).to have_http_status(:success)
+          expect(response.body).to have_content course.name
+        end
+      end
+      describe "when hidden course's ID given" do
+        it 'returns authorization error' do
+          course.hidden = true
+          course.save!
+          get :find_by_id, id: course.id
+          expect(response).to have_http_status(403)
+          expect(response.body).to have_content "You are not authorized"
+        end
+      end
+      describe 'when invalid course ID given' do
+        it 'shows error' do
+          get :find_by_id, id: -1
+          expect(response).to have_http_status(:missing)
+          expect(response.body).to have_content "Couldn't find Course"
+        end
+      end
+    end
+
+    describe 'as guest' do
+      let(:token) { double resource_owner_id: user.id, acceptable?: true }
+
+      describe 'when course ID given' do
+        it 'returns authorization error' do
+          get :find_by_id, id: course.id
+          expect(response).to have_http_status(:success)
+          expect(response.body).to have_content course.name
+        end
+      end
+      describe "when hidden course's ID given" do
+        it 'returns authorization error' do
+          course.hidden = true
+          course.save!
+          get :find_by_id, id: course.id
+          expect(response).to have_http_status(403)
+          expect(response.body).to have_content "You are not authorized"
+        end
+      end
+      describe 'when invalid course ID given' do
+        it 'shows error' do
+          get :find_by_id, id: -1
+          expect(response).to have_http_status(:missing)
+          expect(response.body).to have_content "Couldn't find Course"
+        end
+      end
+    end
+
+  end
+
+  describe 'GET find_by_id' do
+
+    describe 'when logged as admin' do
+      let(:token) { double resource_owner_id: admin.id, acceptable?: true }
+
+      describe 'when organization id and course name given' do
+        it 'shows course information' do
+          get :find_by_name, {slug: organization.slug, name: course_name}
+          expect(response).to have_http_status(:success)
+          expect(response.body).to have_content course.name
+        end
+      end
+      describe "when hidden course's organization id and course name given" do
+        it 'shows course information' do
+          course.hidden = true
+          course.save!
+          get :find_by_name, {slug: organization.slug, name: course_name}
+          expect(response).to have_http_status(:success)
+          expect(response.body).to have_content course.name
+        end
+      end
+      describe "when invalid organization id and valid course name given" do
+        it 'shows error' do
+          get :find_by_name, {slug: "bad", name: course_name}
+          expect(response).to have_http_status(:missing)
+          expect(response.body).to have_content "Couldn't find Course"
+        end
+      end
+      describe "when valid organization id and invalid course name given" do
+        it 'shows error' do
+          get :find_by_name, {slug: organization.slug, name: "bad"}
+          expect(response).to have_http_status(:missing)
+          expect(response.body).to have_content "Couldn't find Course"
+        end
+      end
+    end
+
+    describe 'when logged as user' do
+      let(:token) { double resource_owner_id: user.id, acceptable?: true }
+
+      describe 'when organization id and course name given' do
+        it 'shows course information' do
+          get :find_by_name, {slug: organization.slug, name: course_name}
+          expect(response).to have_http_status(:success)
+          expect(response.body).to have_content course.name
+        end
+      end
+      describe "when hidden course's organization id and course name given" do
+        it 'shows course information' do
+          course.hidden = true
+          course.save!
+          get :find_by_name, {slug: organization.slug, name: course_name}
+          expect(response).to have_http_status(403)
+          expect(response.body).to have_content "You are not authorized"
+        end
+      end
+      describe "when invalid organization id and valid course name given" do
+        it 'shows error' do
+          get :find_by_name, {slug: "bad", name: course_name}
+          expect(response).to have_http_status(:missing)
+          expect(response.body).to have_content "Couldn't find Course"
+        end
+      end
+      describe "when valid organization id and invalid course name given" do
+        it 'shows error' do
+          get :find_by_name, {slug: organization.slug, name: "bad"}
+          expect(response).to have_http_status(:missing)
+          expect(response.body).to have_content "Couldn't find Course"
+        end
+      end
+    end
+
+    describe 'as guest' do
+      let(:token) { double resource_owner_id: user.id, acceptable?: true }
+
+      describe 'when organization id and course name given' do
+        it 'shows course information' do
+          get :find_by_name, {slug: organization.slug, name: course_name}
+          expect(response).to have_http_status(:success)
+          expect(response.body).to have_content course.name
+        end
+      end
+      describe "when hidden course's organization id and course name given" do
+        it 'shows course information' do
+          course.hidden = true
+          course.save!
+          get :find_by_name, {slug: organization.slug, name: course_name}
+          expect(response).to have_http_status(403)
+          expect(response.body).to have_content "You are not authorized"
+        end
+      end
+      describe "when invalid organization id and valid course name given" do
+        it 'shows error' do
+          get :find_by_name, {slug: "bad", name: course_name}
+          expect(response).to have_http_status(:missing)
+          expect(response.body).to have_content "Couldn't find Course"
+        end
+      end
+      describe "when valid organization id and invalid course name given" do
+        it 'shows error' do
+          get :find_by_name, {slug: organization.slug, name: "bad"}
+          expect(response).to have_http_status(:missing)
+          expect(response.body).to have_content "Couldn't find Course"
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v8/courses_controller_spec.rb
+++ b/spec/controllers/api/v8/courses_controller_spec.rb
@@ -172,13 +172,13 @@ describe Api::V8::CoursesController, type: :controller do
     end
 
     describe 'as guest' do
-      let(:token) { double resource_owner_id: user.id, acceptable?: true }
+      let(:token) { nil }
 
       describe 'when organization id and course name given' do
         it 'shows course information' do
           get :find_by_name, {slug: organization.slug, name: course_name}
-          expect(response).to have_http_status(:success)
-          expect(response.body).to have_content course.name
+          expect(response).to have_http_status(403)
+          expect(response.body).to have_content "Authentication required"
         end
       end
       describe "when hidden course's organization id and course name given" do

--- a/spec/controllers/api/v8/courses_controller_spec.rb
+++ b/spec/controllers/api/v8/courses_controller_spec.rb
@@ -134,7 +134,7 @@ describe Api::V8::CoursesController, type: :controller do
           expect(response.body).to have_content "Couldn't find Course"
         end
       end
-      describe "when invalidvalid organization id and invalid course name given" do
+      describe "when invalid organization id and invalid course name given" do
         it "error about finding course" do
           get :find_by_name, {slug: "bad", name: "bad"}
           expect(response).to have_http_status(:missing)
@@ -176,6 +176,13 @@ describe Api::V8::CoursesController, type: :controller do
           expect(response.body).to have_content "Couldn't find Course"
         end
       end
+      describe "when invalid organization id and invalid course name given" do
+        it "error about finding course" do
+          get :find_by_name, {slug: "bad", name: "bad"}
+          expect(response).to have_http_status(:missing)
+          expect(response.body).to have_content "Couldn't find Course"
+        end
+      end
     end
 
     describe "as guest" do
@@ -207,6 +214,13 @@ describe Api::V8::CoursesController, type: :controller do
       describe "when valid organization id and invalid course name given" do
         it "shows authentication error" do
           get :find_by_name, {slug: organization.slug, name: "bad"}
+          expect(response).to have_http_status(403)
+          expect(response.body).to have_content "Authentication required"
+        end
+      end
+      describe "when invalid organization id and invalid course name given" do
+        it "shows authentication error" do
+          get :find_by_name, {slug: "bad", name: "bad"}
           expect(response).to have_http_status(403)
           expect(response.body).to have_content "Authentication required"
         end


### PR DESCRIPTION
Kurssin haku 
- /api/v8/organizations/:org_slug/courses/:course_name 
- /api/v8/courses/:course_id
- tests
- documentation

This closes #429 and closes #430 
@testmycode/api-team 

Jenkins builds:
- http://ohtu-jenkins.testmycode.io/job/tmc-server-api-course-search/5/
- http://ohtu-jenkins.testmycode.io/job/tmc-server-api-course-search/6/