### PR TITLE
Split refresh

### DIFF
--- a/app/background_tasks/background_course_refresher_task.rb
+++ b/app/background_tasks/background_course_refresher_task.rb
@@ -1,0 +1,11 @@
+require 'background_course_refresher'
+
+class BackgroundCourseRefresherTask
+  def initialize
+    @refresher = BackgroundCourseRefresher.new
+  end
+
+  def run
+    @refresher.do_refresh
+  end
+end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -12,6 +12,7 @@ class OrganizationsController < ApplicationController
     @my_organizations |= Organization.assisted_organizations(current_user)
     @my_organizations |= Organization.participated_organizations(current_user)
     @my_organizations.natsort_by!(&:name)
+    @courses_under_initial_refresh = Course.where(initial_refresh_ready: false)
   end
 
   def show

--- a/app/controllers/setup/course_assistants_controller.rb
+++ b/app/controllers/setup/course_assistants_controller.rb
@@ -26,6 +26,7 @@ class Setup::CourseAssistantsController < Setup::SetupController
       if @assistantship.save
         redirect_to setup_organization_course_course_assistants_path, notice: "Assistant #{new_assistant.login} added"
       else
+        @setup_in_progress = setup_in_progress?
         @assistants = @course.assistants
         if setup_in_progress?
           print_setup_phases(4)

--- a/app/controllers/setup/course_details_controller.rb
+++ b/app/controllers/setup/course_details_controller.rb
@@ -37,18 +37,7 @@ class Setup::CourseDetailsController < Setup::SetupController
     if @course.save
       # Fast refresh without time-consuming tasks, like making solutions
       refresh_course(@course, no_directory_changes: @course.course_template.cache_exists?, no_background_operations: true)
-
-      # Full refresh on background
-      Thread.new do
-        begin
-          logger.info("Starting background initial refresh on course #{@course.name} (id #{@course.id})")
-          refresh_course(@course, no_directory_changes: @course.course_template.cache_exists?)
-          @course.initial_refresh_ready = true
-          @course.save!
-        rescue
-          logger.warn("Failed to do full initial refresh on course #{@course.name} (id #{@course.id})")
-        end
-      end
+      # Full refresh happens as background task
 
       update_setup_course(@course.id)
       redirect_to setup_organization_course_course_timing_path(@organization.slug, @course.id)

--- a/app/controllers/setup/course_finisher_controller.rb
+++ b/app/controllers/setup/course_finisher_controller.rb
@@ -14,10 +14,11 @@ class Setup::CourseFinisherController < Setup::SetupController
 
     if params[:commit] == 'Publish now'
       @course.enabled!
-    else
+      @course.save!
+    elsif params[:commit] == 'Finish and publish later'
       @course.disabled!
+      @course.save!
     end
-    @course.save!
 
     reset_setup_session
     redirect_to organization_course_path(@organization, @course)

--- a/app/controllers/setup/course_timings_controller.rb
+++ b/app/controllers/setup/course_timings_controller.rb
@@ -141,11 +141,9 @@ class Setup::CourseTimingsController < Setup::SetupController
   private
 
   def groups_as_array
-    names = ['']
-    @course.exercise_groups.each do |group|
-      names << group.name
+    @course.exercise_groups.each_with_object(['']) do |group, array|
+      array << group.name
     end
-    names
   end
 
   def group_params

--- a/app/controllers/setup/course_timings_controller.rb
+++ b/app/controllers/setup/course_timings_controller.rb
@@ -23,7 +23,12 @@ class Setup::CourseTimingsController < Setup::SetupController
       when 'no_unlocks'
         clear_all_unlocks
       when 'percent_from_previous'
-        unlocks_previous_set_completed(80)
+        percentage = params[:unlock_percentage]
+        unless percentage.to_i.between?(1, 100)
+          redirect_to setup_organization_course_course_timing_path, notice: 'Please insert correct unlock percentage'
+          return
+        end
+        unlocks_previous_set_completed(percentage)
       end
 
       first_set_date = params[:first_set_date]

--- a/app/helpers/course_timings_helper.rb
+++ b/app/helpers/course_timings_helper.rb
@@ -1,0 +1,22 @@
+module CourseTimingsHelper
+  def parse_percentage_from_unlock_condition(condition)
+    if condition =~ /^(\d+)[%]\s+(?:in|of|from)\s+(\S+)$/
+      percentage = Integer($1)
+    end
+    percentage
+  end
+
+  def parse_group_from_unlock_condition(condition)
+    if condition =~ /^(\d+)[%]\s+(?:in|of|from)\s+(\S+)$/
+      condition.split.last
+    end
+  end
+
+  def complex_unlock_conditions?(group)
+    return false if group.group_unlock_conditions.empty?
+    return true if group.group_unlock_conditions.length > 1
+    return false if group.group_unlock_conditions.first.empty?
+    return true unless group.group_unlock_conditions.first =~ /^(\d+)[%]\s+(?:in|of|from)\s+(\S+)$/
+    false
+  end
+end

--- a/app/helpers/course_timings_helper.rb
+++ b/app/helpers/course_timings_helper.rb
@@ -1,15 +1,13 @@
 module CourseTimingsHelper
   def parse_percentage_from_unlock_condition(condition)
     if condition =~ /^(\d+)[%]\s+(?:in|of|from)\s+(\S+)$/
-      percentage = Integer($1)
+      percentage = Integer(Regexp.last_match(1))
     end
     percentage
   end
 
   def parse_group_from_unlock_condition(condition)
-    if condition =~ /^(\d+)[%]\s+(?:in|of|from)\s+(\S+)$/
-      condition.split.last
-    end
+    condition.split.last if condition =~ /^(\d+)[%]\s+(?:in|of|from)\s+(\S+)$/
   end
 
   def complex_unlock_conditions?(group)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -170,6 +170,7 @@ class Course < ActiveRecord::Base
     user.administrator? ||
     user.teacher?(organization) ||
     user.assistant?(self) || (
+      initial_refresh_ready? &&
       !disabled? &&
       !hidden &&
       (hide_after.nil? || hide_after > Time.now) &&

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -327,7 +327,7 @@ class Exercise < ActiveRecord::Base
     if returnable_forced != nil
       returnable_forced # may be true or false
     else
-      has_tests?
+      has_tests? && course.initial_refresh_ready?
     end
   end
 

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -3,6 +3,11 @@
     <h1><%= @course.title %></h1>
 
     <div>
+      <% unless @course.initial_refresh_ready? %>
+        <p><strong>
+          Course is being updated! It doesn't accept any submissions yet. Please wait.
+        </strong></p>
+      <% end %>
       <% unless @course.description.blank? %>
         <p><%= @course.description %></p>
       <% end %>

--- a/app/views/exercises/_list.html.erb
+++ b/app/views/exercises/_list.html.erb
@@ -40,7 +40,9 @@
           <% end %>
         </td>
         <td>
-          <%= link_to 'zip', exercise_zip_url(exercise) %>
+          <%= link_to_if @course.initial_refresh_ready?, 'zip', exercise_zip_url(exercise) do %>
+            zip not available yet
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/app/views/exercises/show.html.erb
+++ b/app/views/exercises/show.html.erb
@@ -2,7 +2,11 @@
 <h1><%= @exercise.name %></h1>
 
 <ul>
-  <li><%= link_to 'Download project template (zip)', exercise_zip_url(@exercise) %></li>
+  <li>
+    <%= link_to_if @course.initial_refresh_ready?, 'Download project template (zip)', exercise_zip_url(@exercise) do %>
+      Project template (zip) not available during refresh.
+    <% end %>
+  </li>
 
   <% if !@exercise.available_points.empty? && !@course.hide_submission_results?  %>
     <%
@@ -68,7 +72,11 @@
   <% end %>
 
   <% if @exercise.solution && can?(:read, @exercise.solution) %>
-    <li><%= link_to 'View suggested solution', exercise_solution_path(@exercise) %></li>
+    <li>
+      <%= link_to_if @course.initial_refresh_ready?, 'View suggested solution', exercise_solution_path(@exercise) do %>
+        Solution not available during refresh.
+      <% end %>
+    </li>
   <% end %>
 
   <% if can? :read, FeedbackAnswer %>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -7,6 +7,17 @@
   </div>
 <% end %>
 
+<% if current_user.administrator? && @courses_under_initial_refresh %>
+  <div class="alert alert-warning" role="alert">
+    <%=pluralize(@courses_under_initial_refresh.count, 'course')%> under initial refresh!
+    <ul>
+      <% @courses_under_initial_refresh.each do |c| %>
+        <li><%= link_to(c.title, organization_course_path(c.organization, c))%> (started at: <%=c.created_at%>)</li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
 <% unless @my_organizations.empty? %>
   <h2>My organizations</h2>
 

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -12,7 +12,8 @@
     <%=pluralize(@courses_under_initial_refresh.count, 'course')%> under initial refresh!
     <ul>
       <% @courses_under_initial_refresh.each do |c| %>
-        <li><%= link_to(c.title, organization_course_path(c.organization, c))%> (started at: <%=c.created_at%>)</li>
+        <li><%= link_to(c.title, organization_course_path(c.organization, c))%>
+          (organization: <%=c.organization.name%>, started at: <%=c.created_at%>)</li>
       <% end %>
     </ul>
   </div>

--- a/app/views/setup/course_finisher/index.html.erb
+++ b/app/views/setup/course_finisher/index.html.erb
@@ -4,16 +4,32 @@
 
 <h2>Course is ready!</h2>
 
-<p>
-  Your course is now set up and ready to use!
-</p>
+<% if @course.initial_refresh_ready? %>
+  <p>
+    Your course is now set up and ready to use!
+  </p>
+  <p>
+    Initially, the course is set to be on disabled status, so it is hidden, until you decide to publish it.
+    You can choose to publish it now or later.
+  </p>
 
-<p>
-  Initially, the course is set to be on disabled status, so it is hidden, until you decide to publish it.
-  You can choose to publish it now or later.
-</p>
-
-<%= form_tag(setup_organization_course_course_finisher_index_path, method: 'post') do %>
+  <%= form_tag(setup_organization_course_course_finisher_index_path, method: 'post') do %>
     <%= submit_tag('Publish now') %>
     <%= submit_tag('Finish and publish later') %>
+  <% end %>
+<% else %>
+  <p>
+    Your course is now set up!
+  </p>
+  <p>
+    However, exercices are still being initialized, and the course can't be yet published to accept submissions.
+    Normally this initialization process should be ready in maximum one hour, and the course main page tells
+    if the updating is still going on.
+  </p>
+  <p>
+    The course will be on disabled status, so you have to later manually publish it, when you want students to have access on it.
+  </p>
+  <%= form_tag(setup_organization_course_course_finisher_index_path, method: 'post') do %>
+    <%= submit_tag('Finish') %>
+  <% end %>
 <% end %>

--- a/app/views/setup/course_timings/show.html.erb
+++ b/app/views/setup/course_timings/show.html.erb
@@ -6,8 +6,19 @@
       validateOnBlur: false,
       allowBlank: true,
       enterLikeTab: false,
-      defaultTime: '23:59',
-      format: 'd.m.Y H:i'
+      timepicker: false,
+      format: 'd.m.Y'
+    });
+  });
+
+  $(function(){
+    $("input[name=unlock_type]").change(function(){
+      var e = document.getElementById('unlock_percentage');
+      if ($("input[name=unlock_type]:checked").val() == 'no_unlocks') {
+        e.disabled = true;
+      } else if ($("input[name=unlock_type]:checked").val() == 'percent_from_previous') {
+        e.disabled = false;
+      }
     });
   });
 </script>
@@ -21,12 +32,12 @@
 <% end %>
 
 <p>
-  Here you will schedule the course and exercise sets. Unlock means the condition when exercises are visible
-  and downloadable. Deadline defines the moment, when the submissions has to be made.
+  Here you will schedule the course and exercise sets. Deadline defines the moment, when the submissions has to be made.
+  Unlock means the condition when exercises become available for the student.
 </p>
 
 <p>
-  First choose basic option for both unlocks and deadlines. After that you can check if the details are good
+  First choose basic option for both deadlines and unlocks. After that you can check if the details are good
   or manually adjust them. These options will cover most common initial choices, but full customization
   can be made later on advanced settings.
 </p>
@@ -34,29 +45,32 @@
   <%= form_tag setup_organization_course_course_timing_path(course_id: @course.id), method: 'PUT' do %>
 
     <!--
-    <%= label_tag :start_date, 'Course start date: (not yet implemented)'%>
-    <%= date_field :start_date, nil  %>
+    <% label_tag :start_date, 'Course start date: (not yet implemented)'%>
+    <% date_field :start_date, nil  %>
     -->
-    <hr>
-    <h3>Unlocks</h3>
-    Choose the type, how the exercises are opened:<br>
-    <%= radio_button_tag :unlock_type, "no_unlocks", (params[:unlock_type] == "no_unlocks") %>
-    <%= label_tag :unlock_type_1, 'Everything open at start' %>
-    <%= radio_button_tag :unlock_type, "percent_from_previous", (params[:unlock_type] == "percent_from_previous") %>
-    <%= label_tag :unlock_type_2, '80% from previous set completed' %>
 
-    <hr>
     <h3>Deadlines</h3>
     <%= label_tag :first_set_date, 'Deadline for first set:'%>
     <%= date_field :first_set_date, nil  %>
     <br>
     Choose how incoming exercise set deadlines are set:<br>
     <%= radio_button_tag :deadline_type, "no_deadlines" %>
-    <%= label_tag :deadline_type_1, 'No deadlines' %>
+    <%= label_tag :deadline_type_1, 'No deadlines', class: 'radio inline' %><br>
     <%= radio_button_tag :deadline_type, "weekly_deadlines" %>
-    <%= label_tag :deadline_type_2, 'Weekly' %>
+    <%= label_tag :deadline_type_2, 'Weekly', class: 'radio inline' %><br>
     <%= radio_button_tag :deadline_type, "all_same_deadline" %>
-    <%= label_tag :deadline_type_3, 'All same' %>
+    <%= label_tag :deadline_type_3, 'All same', class: 'radio inline' %><br>
+
+    <h3>Unlocks</h3>
+    Choose the type, how the exercises are opened:<br>
+    <%= radio_button_tag :unlock_type, "no_unlocks", (params[:unlock_type] == "no_unlocks") %>
+    <%= label_tag :unlock_type_1, 'Everything open at start', class: 'radio inline' %><br>
+    <%= radio_button_tag :unlock_type, "percent_from_previous", (params[:unlock_type] == "percent_from_previous") %>
+    <%= label_tag :unlock_type_2, 'Percentage from previous set completed', class: 'radio inline' %><br>
+    <div style="margin-left: 36px;">
+      <%= number_field_tag :unlock_percentage, '80', min: 0, max:100, style: "width: 3em", disabled: true %>% needed
+    </div>
+
     <br>
     <%= submit_tag 'Fill and preview', class: 'btn' %>
 

--- a/app/views/setup/course_timings/show.html.erb
+++ b/app/views/setup/course_timings/show.html.erb
@@ -55,18 +55,18 @@
     <br>
     Choose how incoming exercise set deadlines are set:<br>
     <%= radio_button_tag :deadline_type, "no_deadlines" %>
-    <%= label_tag :deadline_type_1, 'No deadlines', class: 'radio inline' %><br>
+    <%= label_tag :deadline_type_no_deadlines, 'No deadlines', class: 'radio inline' %><br>
     <%= radio_button_tag :deadline_type, "weekly_deadlines" %>
-    <%= label_tag :deadline_type_2, 'Weekly', class: 'radio inline' %><br>
+    <%= label_tag :deadline_type_weekly_deadlines, 'Weekly', class: 'radio inline' %><br>
     <%= radio_button_tag :deadline_type, "all_same_deadline" %>
-    <%= label_tag :deadline_type_3, 'All same', class: 'radio inline' %><br>
+    <%= label_tag :deadline_type_all_same_deadline, 'All same', class: 'radio inline' %><br>
 
     <h3>Unlocks</h3>
     Choose the type, how the exercises are opened:<br>
     <%= radio_button_tag :unlock_type, "no_unlocks", (params[:unlock_type] == "no_unlocks") %>
-    <%= label_tag :unlock_type_1, 'Everything open at start', class: 'radio inline' %><br>
+    <%= label_tag :unlock_type_no_unlocks, 'Everything open at start', class: 'radio inline' %><br>
     <%= radio_button_tag :unlock_type, "percent_from_previous", (params[:unlock_type] == "percent_from_previous") %>
-    <%= label_tag :unlock_type_2, 'Percentage from previous set completed', class: 'radio inline' %><br>
+    <%= label_tag :unlock_type_percent_from_previous, 'Percentage from previous set completed', class: 'radio inline' %><br>
     <div style="margin-left: 36px;">
       <%= number_field_tag :unlock_percentage, '80', min: 0, max:100, style: "width: 3em", disabled: true %>% needed
     </div>

--- a/app/views/setup/course_timings/show.html.erb
+++ b/app/views/setup/course_timings/show.html.erb
@@ -102,21 +102,31 @@
 
             <% #### Unlocks #### %>
             <td>
-              <%
-                if group.name.empty?
-                  param_array = 'empty_group'
-                else
-                  param_array = "group[#{group.name}]"
-                end
+              <% if complex_unlock_conditions?(group) %>
+                Complex conditions
+              <% else %>
+                <%
+                  if group.name.empty?
+                    param_array = 'empty_group'
+                  else
+                    param_array = "group[#{group.name}]"
+                  end
 
-                group_unlock_conditions = group.group_unlock_conditions
-                group_unlock_conditions = [''] if group_unlock_conditions.empty? # Always have at least one input field
-              %>
-              <div id="unlock-condition-<%= group.name %>">
-                <% group_unlock_conditions.each_with_index do |condition, i| %>
-                    <%= text_field_tag "#{param_array}[#{i}]", condition %>
-                <% end %>
-              </div>
+                  group_unlock_conditions = group.group_unlock_conditions
+                  group_unlock_conditions = [''] if group_unlock_conditions.empty? # Always have at least one input field
+                %>
+                <div id="unlock-condition-<%= group.name %>">
+                  <% condition = group_unlock_conditions.first %>
+                  <%= radio_button_tag "#{param_array}_unlock_option", 'no_unlock', condition.blank? %>
+                  <%= label_tag "#{param_array}_unlock_option_no_unlock", "No unlock", class: 'radio inline' %>
+                  <br>
+                  <%= radio_button_tag "#{param_array}_unlock_option", 'percentage_from', !condition.blank? %>
+                  <%= label_tag "#{param_array}_unlock_option_percentage from", 'Requires ', class: 'radio inline' %>
+                  <%= number_field_tag "#{param_array}_percentage_required", '80', min: 1, max:100, style: "width: 3em", value: parse_percentage_from_unlock_condition(condition) %>
+                  % from
+                  <%= select_tag "#{param_array}_unlock_groupname", options_for_select(@group_array, selected: parse_group_from_unlock_condition(condition)) %>
+                </div>
+              <% end %>
             </td>
 
             <% #### Deadlines %>

--- a/db/migrate/20161024122339_add_initial_refresh_ready_to_course.rb
+++ b/db/migrate/20161024122339_add_initial_refresh_ready_to_course.rb
@@ -1,10 +1,7 @@
 class AddInitialRefreshReadyToCourse < ActiveRecord::Migration
   def up
     add_column :courses, :initial_refresh_ready, :boolean, default: false
-    Course.all.each do |c|
-      c.initial_refresh_ready = true
-      c.save!
-    end
+    Course.update_all(initial_refresh_ready: true)
   end
 
   def down

--- a/db/migrate/20161024122339_add_initial_refresh_ready_to_course.rb
+++ b/db/migrate/20161024122339_add_initial_refresh_ready_to_course.rb
@@ -1,0 +1,13 @@
+class AddInitialRefreshReadyToCourse < ActiveRecord::Migration
+  def up
+    add_column :courses, :initial_refresh_ready, :boolean, default: false
+    Course.all.each do |c|
+      c.initial_refresh_ready = true
+      c.save!
+    end
+  end
+
+  def down
+    remove_column :courses, :initial_refresh_ready
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160804120140) do
+ActiveRecord::Schema.define(version: 20161024122339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,6 +110,7 @@ ActiveRecord::Schema.define(version: 20160804120140) do
     t.integer  "course_template_id",                             null: false
     t.boolean  "hide_submission_results",        default: false
     t.string   "external_scoreboard_url"
+    t.boolean  "initial_refresh_ready",          default: false
   end
 
   add_index "courses", ["organization_id"], name: "index_courses_on_organization_id", using: :btree

--- a/lib/background_course_refresher.rb
+++ b/lib/background_course_refresher.rb
@@ -1,0 +1,17 @@
+class BackgroundCourseRefresher
+  # Called periodically by script/background_daemon, does full refresh on courses which
+  # still need full initial refresh.
+  def do_refresh
+    Course.where(initial_refresh_ready: false).where.not(refreshed_at: nil).each do |course|
+      Rails.logger.info "Starting background refresh on course id #{course.id}"
+      begin
+        course.refresh(no_directory_changes: course.course_template.cache_exists?)
+        course.initial_refresh_ready = true
+        course.save!
+        Rails.logger.info "Finished background refresh on course id #{course.id}"
+      rescue
+        Rails.logger.warn "Background refresh on course id #{course.id} failed!"
+      end
+    end
+  end
+end

--- a/lib/course_refresher.rb
+++ b/lib/course_refresher.rb
@@ -114,7 +114,7 @@ class CourseRefresher
           measure_and_log :delete_records_for_removed_exercises
           measure_and_log :update_exercise_options
           measure_and_log :set_has_tests_flags
-          measure_and_log :update_available_points
+          measure_and_log :update_available_points                unless options[:no_background_operations]
           measure_and_log :make_solutions                         unless options[:no_directory_changes]
           measure_and_log :make_stubs                             unless options[:no_directory_changes]
           measure_and_log :checksum_stubs
@@ -292,7 +292,7 @@ class CourseRefresher
           point_names += points_data.map { |x| x[:points] }.flatten
         else
           point_names += points_data.flatten
-	end
+        end
 
         point_names += review_points
 

--- a/spec/controllers/setup/course_details_controller_spec.rb
+++ b/spec/controllers/setup/course_details_controller_spec.rb
@@ -47,6 +47,7 @@ describe Setup::CourseDetailsController, type: :controller do
           expect do
             post :create, organization_id: @organization.slug, course: { name: 'NewCourse', title: 'New Course', course_template_id: @ct.id }
           end.to change { Course.count }.by(1)
+          expect(Course.last.initial_refresh_ready).to be_falsey
         end
 
         it 'redirects to the created course' do

--- a/spec/controllers/setup/course_timings_controller_spec.rb
+++ b/spec/controllers/setup/course_timings_controller_spec.rb
@@ -115,9 +115,9 @@ describe Setup::CourseTimingsController, type: :controller do
             course_id: @course.id,
             commit: 'Accept and continue',
             group: {
-                group1: {'0'=>'', 'hard'=>{'static'=>'2016-06-16'}},
-                group2: {'0'=>'', 'hard'=>{'static'=>'2016-07-16'}},
-                group3: {'0'=>'', 'hard'=>{'static'=>'2016-08-16'}}
+                group1: {'_unlock_option'=>'no_unlock', 'hard'=>{'static'=>'2016-06-16'}},
+                group2: {'_unlock_option'=>'no_unlock', 'hard'=>{'static'=>'2016-07-16'}},
+                group3: {'_unlock_option'=>'no_unlock', 'hard'=>{'static'=>'2016-08-16'}}
             }
         }
         expect(assigns(:course).exercise_group_by_name('group1').hard_group_deadline.static_deadline_spec).to eq('2016-06-16')
@@ -131,9 +131,9 @@ describe Setup::CourseTimingsController, type: :controller do
             course_id: @course.id,
             commit: 'Accept and continue',
             group: {
-                group1: {'0'=>'', 'hard'=>{'static'=>''}},
-                group2: {'0'=>'92% from group1', 'hard'=>{'static'=>''}},
-                group3: {'0'=>'94% from group2', 'hard'=>{'static'=>''}}
+                group1: {'_unlock_option'=>'no_unlock', 'hard'=>{'static'=>''}},
+                group2: {'_unlock_option'=>'percentage_from', '_percentage_required'=>'92', '_unlock_groupname'=>'group1', 'hard'=>{'static'=>''}},
+                group3: {'_unlock_option'=>'percentage_from', '_percentage_required'=>'94', '_unlock_groupname'=>'group2', 'hard'=>{'static'=>''}}
             }
         }
         expect(assigns(:course).exercise_group_by_name('group1').group_unlock_conditions).to eq([''])
@@ -148,9 +148,9 @@ describe Setup::CourseTimingsController, type: :controller do
             course_id: @course.id,
             commit: 'Accept and continue',
             group: {
-                group1: {'0'=>'', 'hard'=>{'static'=>''}},
-                group2: {'0'=>'92% from group1', 'hard'=>{'static'=>''}},
-                group3: {'0'=>'94% from group2', 'hard'=>{'static'=>''}}
+                group1: {'_unlock_option'=>'no_unlock', 'hard'=>{'static'=>''}},
+                group2: {'_unlock_option'=>'percentage_from', '_percentage_required'=>'92', '_unlock_groupname'=>'group1', 'hard'=>{'static'=>''}},
+                group3: {'_unlock_option'=>'percentage_from', '_percentage_required'=>'94', '_unlock_groupname'=>'group2', 'hard'=>{'static'=>''}}
             }
         }
         expect(response).to redirect_to(setup_organization_course_course_assistants_path(@organization, @course))
@@ -162,9 +162,9 @@ describe Setup::CourseTimingsController, type: :controller do
             course_id: @course.id,
             commit: 'Accept and continue',
             group: {
-                group1: {'0'=>'', 'hard'=>{'static'=>''}},
-                group2: {'0'=>'92% from group1', 'hard'=>{'static'=>''}},
-                group3: {'0'=>'94% from group2', 'hard'=>{'static'=>''}}
+                group1: {'_unlock_option'=>'no_unlock', 'hard'=>{'static'=>''}},
+                group2: {'_unlock_option'=>'percentage_from', '_percentage_required'=>'92', '_unlock_groupname'=>'group1', 'hard'=>{'static'=>''}},
+                group3: {'_unlock_option'=>'percentage_from', '_percentage_required'=>'94', '_unlock_groupname'=>'group2', 'hard'=>{'static'=>''}}
             }
         }
         expect(response).to redirect_to(organization_course_path(@organization, @course))

--- a/spec/controllers/setup/course_timings_controller_spec.rb
+++ b/spec/controllers/setup/course_timings_controller_spec.rb
@@ -59,11 +59,12 @@ describe Setup::CourseTimingsController, type: :controller do
             organization_id: @organization.slug,
             course_id: @course.id,
             commit: 'Fill and preview',
-            unlock_type: 'percent_from_previous'
+            unlock_type: 'percent_from_previous',
+            unlock_percentage: '73'
         }
         expect(assigns(:course).exercise_group_by_name('group1').group_unlock_conditions).to eq([])
-        expect(assigns(:course).exercise_group_by_name('group2').group_unlock_conditions).to eq(['80% from group1'])
-        expect(assigns(:course).exercise_group_by_name('group3').group_unlock_conditions).to eq(['80% from group2'])
+        expect(assigns(:course).exercise_group_by_name('group2').group_unlock_conditions).to eq(['73% from group1'])
+        expect(assigns(:course).exercise_group_by_name('group3').group_unlock_conditions).to eq(['73% from group2'])
       end
 
       it 'clears all deadlines' do

--- a/spec/controllers/setup/course_timings_controller_spec.rb
+++ b/spec/controllers/setup/course_timings_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Setup::CourseTimingsController, type: :controller do
-
   before :each do
     @organization = FactoryGirl.create(:accepted_organization)
     @teacher = FactoryGirl.create(:user)
@@ -17,18 +16,18 @@ describe Setup::CourseTimingsController, type: :controller do
 
     describe 'GET show' do
       it 'show the right course' do
-        get :show, {organization_id: @organization.slug, course_id: @course.id}
+        get :show, organization_id: @organization.slug, course_id: @course.id
         expect(assigns(:organization)).to eq(@organization)
       end
 
       it 'should show wizard bar correctly' do
         init_session
-        get :show, {organization_id: @organization.slug, course_id: @course.id}
+        get :show, organization_id: @organization.slug, course_id: @course.id
         expect(assigns(:course_setup_phases)).not_to be_nil
       end
 
       it 'should not show wizard bar when not in wizard mode' do
-        get :show, {organization_id: @organization.slug, course_id: @course.id}
+        get :show, organization_id: @organization.slug, course_id: @course.id
         expect(assigns(:course_setup_phases)).to be_nil
       end
     end
@@ -43,25 +42,23 @@ describe Setup::CourseTimingsController, type: :controller do
       it 'clear all unlocks' do
         @course.exercise_group_by_name('group2').group_unlock_conditions = ['80% from group1'].to_json
         @course.exercise_group_by_name('group3').group_unlock_conditions = ['80% from group2'].to_json
-        put :update, {
+        put :update,
             organization_id: @organization.slug,
             course_id: @course.id,
             commit: 'Fill and preview',
             unlock_type: 'no_unlocks'
-        }
         expect(assigns(:course).exercise_group_by_name('group1').group_unlock_conditions).to eq([''])
         expect(assigns(:course).exercise_group_by_name('group2').group_unlock_conditions).to eq([''])
         expect(assigns(:course).exercise_group_by_name('group3').group_unlock_conditions).to eq([''])
       end
 
       it 'sets unlock percentages' do
-        put :update, {
+        put :update,
             organization_id: @organization.slug,
             course_id: @course.id,
             commit: 'Fill and preview',
             unlock_type: 'percent_from_previous',
             unlock_percentage: '73'
-        }
         expect(assigns(:course).exercise_group_by_name('group1').group_unlock_conditions).to eq([])
         expect(assigns(:course).exercise_group_by_name('group2').group_unlock_conditions).to eq(['73% from group1'])
         expect(assigns(:course).exercise_group_by_name('group3').group_unlock_conditions).to eq(['73% from group2'])
@@ -71,71 +68,65 @@ describe Setup::CourseTimingsController, type: :controller do
         @course.exercise_group_by_name('group1').hard_group_deadline = ['1.1.2020', ''].to_json
         @course.exercise_group_by_name('group2').hard_group_deadline = ['1.1.2020', ''].to_json
         @course.exercise_group_by_name('group3').hard_group_deadline = ['1.1.2020', ''].to_json
-        put :update, {
+        put :update,
             organization_id: @organization.slug,
             course_id: @course.id,
             commit: 'Fill and preview',
             deadline_type: 'no_deadlines'
-        }
         expect(assigns(:course).exercise_group_by_name('group1').hard_group_deadline.static_deadline_spec).to eq(nil)
         expect(assigns(:course).exercise_group_by_name('group2').hard_group_deadline.static_deadline_spec).to eq(nil)
         expect(assigns(:course).exercise_group_by_name('group3').hard_group_deadline.static_deadline_spec).to eq(nil)
       end
 
       it 'sets weekly deadlines' do
-        put :update, {
+        put :update,
             organization_id: @organization.slug,
             course_id: @course.id,
             commit: 'Fill and preview',
             deadline_type: 'weekly_deadlines',
             first_set_date: ['2021-01-01']
-        }
         expect(assigns(:course).exercise_group_by_name('group1').hard_group_deadline.static_deadline_spec).to eq('2021-01-01')
         expect(assigns(:course).exercise_group_by_name('group2').hard_group_deadline.static_deadline_spec).to eq('2021-01-08')
         expect(assigns(:course).exercise_group_by_name('group3').hard_group_deadline.static_deadline_spec).to eq('2021-01-15')
-
       end
 
       it 'sets same deadlines' do
-        put :update, {
+        put :update,
             organization_id: @organization.slug,
             course_id: @course.id,
             commit: 'Fill and preview',
             deadline_type: 'all_same_deadline',
             first_set_date: ['2021-01-01']
-        }
         expect(assigns(:course).exercise_group_by_name('group1').hard_group_deadline.static_deadline_spec).to eq('2021-01-01')
         expect(assigns(:course).exercise_group_by_name('group2').hard_group_deadline.static_deadline_spec).to eq('2021-01-01')
         expect(assigns(:course).exercise_group_by_name('group3').hard_group_deadline.static_deadline_spec).to eq('2021-01-01')
       end
 
       it 'saves manual deadlines' do
-        put :update, {
+        put :update,
             organization_id: @organization.slug,
             course_id: @course.id,
             commit: 'Accept and continue',
             group: {
-                group1: {'_unlock_option'=>'no_unlock', 'hard'=>{'static'=>'2016-06-16'}},
-                group2: {'_unlock_option'=>'no_unlock', 'hard'=>{'static'=>'2016-07-16'}},
-                group3: {'_unlock_option'=>'no_unlock', 'hard'=>{'static'=>'2016-08-16'}}
+              group1: { '_unlock_option' => 'no_unlock', 'hard' => { 'static' => '2016-06-16' } },
+              group2: { '_unlock_option' => 'no_unlock', 'hard' => { 'static' => '2016-07-16' } },
+              group3: { '_unlock_option' => 'no_unlock', 'hard' => { 'static' => '2016-08-16' } }
             }
-        }
         expect(assigns(:course).exercise_group_by_name('group1').hard_group_deadline.static_deadline_spec).to eq('2016-06-16')
         expect(assigns(:course).exercise_group_by_name('group2').hard_group_deadline.static_deadline_spec).to eq('2016-07-16')
         expect(assigns(:course).exercise_group_by_name('group3').hard_group_deadline.static_deadline_spec).to eq('2016-08-16')
       end
 
       it 'saves manual unlocks' do
-        put :update, {
+        put :update,
             organization_id: @organization.slug,
             course_id: @course.id,
             commit: 'Accept and continue',
             group: {
-                group1: {'_unlock_option'=>'no_unlock', 'hard'=>{'static'=>''}},
-                group2: {'_unlock_option'=>'percentage_from', '_percentage_required'=>'92', '_unlock_groupname'=>'group1', 'hard'=>{'static'=>''}},
-                group3: {'_unlock_option'=>'percentage_from', '_percentage_required'=>'94', '_unlock_groupname'=>'group2', 'hard'=>{'static'=>''}}
+              group1: { '_unlock_option' => 'no_unlock', 'hard' => { 'static' => '' } },
+              group2: { '_unlock_option' => 'percentage_from', '_percentage_required' => '92', '_unlock_groupname' => 'group1', 'hard' => { 'static' => '' } },
+              group3: { '_unlock_option' => 'percentage_from', '_percentage_required' => '94', '_unlock_groupname' => 'group2', 'hard' => { 'static' => '' } }
             }
-        }
         expect(assigns(:course).exercise_group_by_name('group1').group_unlock_conditions).to eq([''])
         expect(assigns(:course).exercise_group_by_name('group2').group_unlock_conditions).to eq(['92% from group1'])
         expect(assigns(:course).exercise_group_by_name('group3').group_unlock_conditions).to eq(['94% from group2'])
@@ -143,30 +134,29 @@ describe Setup::CourseTimingsController, type: :controller do
 
       it 'should redirect to next step if in wizard mode' do
         init_session
-        put :update, {
+        put :update,
             organization_id: @organization.slug,
             course_id: @course.id,
             commit: 'Accept and continue',
             group: {
-                group1: {'_unlock_option'=>'no_unlock', 'hard'=>{'static'=>''}},
-                group2: {'_unlock_option'=>'percentage_from', '_percentage_required'=>'92', '_unlock_groupname'=>'group1', 'hard'=>{'static'=>''}},
-                group3: {'_unlock_option'=>'percentage_from', '_percentage_required'=>'94', '_unlock_groupname'=>'group2', 'hard'=>{'static'=>''}}
+              group1: { '_unlock_option' => 'no_unlock', 'hard' => { 'static' => '' } },
+              group2: { '_unlock_option' => 'percentage_from', '_percentage_required' => '92', '_unlock_groupname' => 'group1', 'hard' => { 'static' => '' } },
+              group3: { '_unlock_option' => 'percentage_from', '_percentage_required' => '94', '_unlock_groupname' => 'group2', 'hard' => { 'static' => '' } }
             }
-        }
         expect(response).to redirect_to(setup_organization_course_course_assistants_path(@organization, @course))
       end
 
       it 'should not redirect to next step if not in wizard mode' do
-        put :update, {
+        put :update,
             organization_id: @organization.slug,
             course_id: @course.id,
             commit: 'Accept and continue',
             group: {
-                group1: {'_unlock_option'=>'no_unlock', 'hard'=>{'static'=>''}},
-                group2: {'_unlock_option'=>'percentage_from', '_percentage_required'=>'92', '_unlock_groupname'=>'group1', 'hard'=>{'static'=>''}},
-                group3: {'_unlock_option'=>'percentage_from', '_percentage_required'=>'94', '_unlock_groupname'=>'group2', 'hard'=>{'static'=>''}}
+              group1: { '_unlock_option' => 'no_unlock', 'hard' => { 'static' => '' } },
+              group2: { '_unlock_option' => 'percentage_from', '_percentage_required' => '92', '_unlock_groupname' => 'group1', 'hard' => { 'static' => '' } },
+              group3: { '_unlock_option' => 'percentage_from', '_percentage_required' => '94', '_unlock_groupname' => 'group2', 'hard' => { 'static' => '' } }
             }
-        }
+
         expect(response).to redirect_to(organization_course_path(@organization, @course))
       end
     end
@@ -178,9 +168,9 @@ describe Setup::CourseTimingsController, type: :controller do
     end
 
     it 'should not allow any access' do
-      get :show, {organization_id: @organization.slug, course_id: @course.id}
+      get :show, organization_id: @organization.slug, course_id: @course.id
       expect(response.code.to_i).to eq(401)
-      put :update, {organization_id: @organization.slug, course_id: @course.id, commit: 'Fill and preview', unlock_type: '1'}
+      put :update, organization_id: @organization.slug, course_id: @course.id, commit: 'Fill and preview', unlock_type: '1'
       expect(response.code.to_i).to eq(401)
     end
   end
@@ -189,9 +179,9 @@ describe Setup::CourseTimingsController, type: :controller do
 
   def init_session
     session[:ongoing_course_setup] = {
-        course_id: @course.id,
-        phase: 3,
-        started: Time.now
+      course_id: @course.id,
+      phase: 3,
+      started: Time.now
     }
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -44,6 +44,7 @@ FactoryGirl.define do
     source_url { make_repo_for_course_template }
     source_backend 'git'
     git_branch 'master'
+    initial_refresh_ready true
     organization
   end
 

--- a/spec/features/admin_propagates_template_changes_to_courses_spec.rb
+++ b/spec/features/admin_propagates_template_changes_to_courses_spec.rb
@@ -82,6 +82,9 @@ feature 'Admin propagates template changes to all courses cloned from template',
 
     Course.find_each do |c|
       c.exercises.first.enabled!
+      c.initial_refresh_ready = true
+      c.enabled!
+      c.save!
     end
 
     user = FactoryGirl.create :user, password: 'foobar'

--- a/spec/features/teacher_creates_course_from_template_spec.rb
+++ b/spec/features/teacher_creates_course_from_template_spec.rb
@@ -56,7 +56,7 @@ feature 'Teacher creates course from course template', feature: true do
     click_button 'Continue'
 
     expect(page).to have_content('Course is ready!')
-    click_button 'Publish now'
+    click_button 'Finish'
 
     expect(page).to have_content('Custom Title')
     expect(page).to have_content('Custom description')

--- a/spec/helpers/course_timings_helper_spec.rb
+++ b/spec/helpers/course_timings_helper_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe CourseTimingsHelper, type: :helper do
+  describe 'integer parsing' do
+    it 'should parse integer right' do
+      condition = '72% from Module_4'
+      expect(parse_percentage_from_unlock_condition(condition)).to be(72)
+    end
+
+    it 'should return nil for other condition types' do
+      expect(parse_percentage_from_unlock_condition('')).to be(nil)
+      expect(parse_percentage_from_unlock_condition('12 exercises from Module_4')).to be(nil)
+      expect(parse_percentage_from_unlock_condition('12 Module_4')).to be(nil)
+      expect(parse_percentage_from_unlock_condition('14.7.2014')).to be(nil)
+    end
+  end
+
+  describe 'group parsing' do
+    it 'should return correct group' do
+      expect(parse_group_from_unlock_condition('72% from Module_4')).to eq('Module_4')
+    end
+
+    it 'should return nil for other condition types' do
+      expect(parse_group_from_unlock_condition('')).to eq(nil)
+      expect(parse_group_from_unlock_condition('12 from Module_4')).to eq(nil)
+      expect(parse_group_from_unlock_condition('12 Module_4')).to eq(nil)
+      expect(parse_group_from_unlock_condition('14.7.2014')).to eq(nil)
+    end
+  end
+
+  describe 'complex condition check' do
+    before(:each) do
+      @course = FactoryGirl.create :course, name: 'test-course-1', title: 'Test Course 1'
+      @ex1 = FactoryGirl.create :exercise, name: 'Module_1-ex1', course: @course
+      @ex2 = FactoryGirl.create :exercise, name: 'Module_1-ex2', course: @course
+      @ex3 = FactoryGirl.create :exercise, name: 'Module_2-ex2', course: @course
+      @group = @course.exercise_group_by_name('Module_1')
+    end
+
+    it 'should return false for simple cases' do
+      @group.group_unlock_conditions = [].to_json
+      expect(complex_unlock_conditions?(@group)).to eq(false)
+      @group.group_unlock_conditions = [''].to_json
+      expect(complex_unlock_conditions?(@group)).to eq(false)
+      @group.group_unlock_conditions = ['91% from Module_2'].to_json
+      expect(complex_unlock_conditions?(@group)).to eq(false)
+    end
+
+    it 'should return true for complex cases' do
+      @group.group_unlock_conditions = ['12 exercises from Module_2'].to_json
+      expect(complex_unlock_conditions?(@group)).to eq(true)
+      @group.group_unlock_conditions = ['14.7.2014'].to_json
+      expect(complex_unlock_conditions?(@group)).to eq(true)
+      @group.group_unlock_conditions = ['91% from Module_2', '14.7.2014'].to_json
+      expect(complex_unlock_conditions?(@group)).to eq(true)
+    end
+  end
+end

--- a/spec/integration/broken_utf8_spec.rb
+++ b/spec/integration/broken_utf8_spec.rb
@@ -9,7 +9,7 @@ describe 'The system, receiving submissions with broken UTF-8', type: :request, 
     @organization = FactoryGirl.create(:accepted_organization, slug: 'slug')
     @teacher = FactoryGirl.create(:user)
     Teachership.create user_id: @teacher.id, organization_id: @organization.id
-    @course = Course.create!(name: 'mycourse', title: 'My Course', source_backend: 'git', source_url: repo_path, organization_id: @organization.id)
+    @course = FactoryGirl.create(:course, name: 'mycourse', title: 'My Course', source_url: repo_path, organization: @organization)
     @repo = clone_course_repo(@course)
     @repo.copy(FixtureExercise.fixture_exercises_root + '/BrokenUtf8')
     @repo.add_commit_push

--- a/spec/integration/paste_usecases_spec.rb
+++ b/spec/integration/paste_usecases_spec.rb
@@ -10,7 +10,7 @@ describe 'The system (used by a student)', type: :request, integration: true do
     @organization = FactoryGirl.create(:accepted_organization, slug: 'slug')
     @teacher = FactoryGirl.create(:user)
     Teachership.create user_id: @teacher.id, organization_id: @organization.id
-    @course = Course.create!(name: 'mycourse', title: 'mycourse', source_backend: 'git', source_url: repo_path, organization: @organization)
+    @course = FactoryGirl.create(:course, name: 'mycourse', title: 'mycourse', source_url: repo_path, organization: @organization)
     @repo = clone_course_repo(@course)
     @repo.copy_simple_exercise('MyExercise')
     @repo.add_commit_push

--- a/spec/integration/personal_deadlines_spec.rb
+++ b/spec/integration/personal_deadlines_spec.rb
@@ -9,7 +9,7 @@ describe 'Personal deadlines', type: :request, integration: true do
     @organization = FactoryGirl.create(:accepted_organization, slug: 'slug')
     @teacher = FactoryGirl.create(:user)
     Teachership.create user_id: @teacher.id, organization_id: @organization.id
-    @course = Course.create!(name: 'mycourse', title: 'mycourse', source_backend: 'git', source_url: repo_path, organization: @organization)
+    @course = FactoryGirl.create(:course, name: 'mycourse', title: 'mycourse', source_url: repo_path, organization: @organization)
     @repo = clone_course_repo(@course)
     @repo.copy_simple_exercise('MyExercise1')
     @repo.copy_simple_exercise('MyExercise2')

--- a/spec/integration/requests/pastes_spec.rb
+++ b/spec/integration/requests/pastes_spec.rb
@@ -9,7 +9,7 @@ describe 'Paste JSON api', type: :request, integration: true do
     @organization = FactoryGirl.create(:accepted_organization, slug: 'slug')
     @teacher = FactoryGirl.create(:user)
     Teachership.create user_id: @teacher.id, organization_id: @organization.id
-    @course = Course.create!(name: 'mycourse', title: 'mycourse', source_backend: 'git', source_url: repo_path, organization: @organization)
+    @course = FactoryGirl.create(:course, name: 'mycourse', title: 'mycourse', source_url: repo_path, organization: @organization)
     @repo = clone_course_repo(@course)
     @repo.copy_simple_exercise('MyExercise')
     @repo.add_commit_push

--- a/spec/integration/stats_view_usecases_spec.rb
+++ b/spec/integration/stats_view_usecases_spec.rb
@@ -9,7 +9,7 @@ describe 'The system (used by an instructor for viewing statistics)', type: :req
     organization = FactoryGirl.create(:accepted_organization, slug: 'slug')
     teacher = FactoryGirl.create(:user)
     Teachership.create user_id: teacher.id, organization_id: organization.id
-    course = Course.create!(name: 'mycourse', title: 'mycourse', source_backend: 'git', source_url: repo_path, organization: organization)
+    course = FactoryGirl.create(:course, name: 'mycourse', title: 'mycourse', source_url: repo_path, organization: organization)
     repo = clone_course_repo(course)
     repo.copy_simple_exercise('EasyExercise')
     repo.copy_simple_exercise('HardExercise')

--- a/spec/integration/student_usecases_spec.rb
+++ b/spec/integration/student_usecases_spec.rb
@@ -10,7 +10,7 @@ describe 'The system (used by a student)', type: :request, integration: true do
     @organization = FactoryGirl.create(:accepted_organization, slug: 'slug')
     @teacher = FactoryGirl.create(:user)
     Teachership.create user_id: @teacher.id, organization_id: @organization.id
-    @course = Course.create!(name: 'mycourse', title: 'mycourse', source_backend: 'git', source_url: repo_path, organization: @organization)
+    @course = FactoryGirl.create(:course, name: 'mycourse', title: 'mycourse', source_url: repo_path, organization: @organization)
     @repo = clone_course_repo(@course)
     @repo.copy_simple_exercise('MyExercise')
     @repo.add_commit_push

--- a/spec/integration/utf8_exercise_spec.rb
+++ b/spec/integration/utf8_exercise_spec.rb
@@ -10,7 +10,7 @@ describe 'The system, receiving submissions with UTF-8 special characters', type
     @organization = FactoryGirl.create(:accepted_organization, slug: 'slug')
     @teacher = FactoryGirl.create(:user)
     Teachership.create user_id: @teacher.id, organization_id: @organization.id
-    @course = Course.create!(name: 'mycourse', title: 'mycourse', source_backend: 'git', source_url: repo_path, organization: @organization)
+    @course = FactoryGirl.create(:course, name: 'mycourse', title: 'mycourse', source_url: repo_path, organization: @organization)
     @repo = clone_course_repo(@course)
     @repo.copy(FixtureExercise.fixture_exercises_root + '/Utf8')
     @repo.add_commit_push

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -51,6 +51,11 @@ describe Course, type: :model do
     end
   end
 
+  it 'should not be visible if initial refresh is not done' do
+    c = FactoryGirl.create(:course, initial_refresh_ready: false)
+    expect(c).not_to be_visible_to(user)
+  end
+
   it 'should be visible if not hidden and hide_after is nil' do
     c = FactoryGirl.create(:course, hidden: false, hide_after: nil)
     expect(c).to be_visible_to(user)

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -161,6 +161,12 @@ describe Exercise, type: :model do
     expect { set_deadline(ex, '2011-07-13 12:34:56:78') }.to raise_error(DeadlineSpec::InvalidSyntaxError)
   end
 
+  it "should not be returnable if course's initial refresh is not completed" do
+    course = FactoryGirl.create(:course, initial_refresh_ready: false)
+    ex = FactoryGirl.create(:exercise, course: course, has_tests: true)
+    expect(ex).not_to be_returnable
+  end
+
   it "should always be submittable by administrators as long as it's returnable" do
     admin = FactoryGirl.create(:admin)
     ex = FactoryGirl.create(:returnable_exercise, course: course)

--- a/spec/support/integration_test_actions.rb
+++ b/spec/support/integration_test_actions.rb
@@ -29,7 +29,7 @@ module IntegrationTestActions
     click_button 'Add Course'
     click_button 'Accept and continue'
     click_button 'Continue'
-    click_button 'Publish now'
+    click_button 'Finish'
 
     expect(page).to have_content(options[:name])
     expect(page).to have_content('help page')
@@ -44,7 +44,7 @@ module IntegrationTestActions
     click_button 'Add Course'
     click_button 'Accept and continue'
     click_button 'Continue'
-    click_button 'Publish now'
+    click_button 'Finish'
 
     expect(page).to have_content(options[:name])
     expect(page).to have_content('help page')

--- a/spec/usermanual/admins.html.erb
+++ b/spec/usermanual/admins.html.erb
@@ -264,5 +264,17 @@ require 'cgi' # for escapeHTML
 %>
 <%= screenshot %>
 
+<h2>Monitoring background refreshes</h2>
+
+<p>
+  When a new course is made, first real-time refresh is made only partly, without generating available points for exercises. Because of that, full refresh is launched on background. As administrator, the front page shows if there are any ongoing background refreshes, and when they are made. Based on that, you can monitor possible problems, if certain course stays on the refresh list for too long time.
+</p>
+
+<%
+  course = FactoryGirl.create(:course, organization: organization, initial_refresh_ready: false)
+  visit '/'
+%>
+<%= screenshot %>
+
 </body>
 </html>

--- a/spec/usermanual/customcourse.html.erb
+++ b/spec/usermanual/customcourse.html.erb
@@ -125,6 +125,8 @@ require 'cgi' # for escapeHTML
     end
     course = Course.last
     expect(course).not_to be_nil
+    course.initial_refresh_ready = true
+    course.save!
 
     click_button 'Accept and continue'
     click_button 'Continue'

--- a/spec/usermanual/teachers.html.erb
+++ b/spec/usermanual/teachers.html.erb
@@ -312,7 +312,7 @@ require 'cgi' # for escapeHTML
 </p>
 
 <%
-  click_on 'Publish now'
+  click_on 'Finish'
 %>
   <h3>The course main page</h3>
 

--- a/spec/usermanual/teachers.html.erb
+++ b/spec/usermanual/teachers.html.erb
@@ -257,11 +257,11 @@ require 'cgi' # for escapeHTML
 </p>
 
 <p>
-  The unlock condition states when the exercises are available. You can either have everything open from start, or have each set require that 80% of the previous set is completed.
+  The unlock condition states when the exercises are available. You can either have everything open from start, or have each set require that certain percentage of the previous set is completed.
 </p>
 
 <p>
-  Deadline is the moment, when the submissions has to be made. TMC refuses to accept any attempts after that. You can choose to have no deadlines at all, weekly deadlines or just single deadline for all exercises. Insert first set deadline if needed. You can also set "soft" deadlines later on using the advanced settings.
+  Deadline is the moment, when the submissions has to be made. By default, exact deadline time is the end of the day set. TMC refuses to accept any attempts after that. You can choose to have no deadlines at all, weekly deadlines or just single deadline for all exercises. Insert first set deadline if needed. You can also set "soft" deadlines later on using the advanced settings.
 </p>
 
 <p>

--- a/spec/usermanual/teachers.html.erb
+++ b/spec/usermanual/teachers.html.erb
@@ -82,7 +82,7 @@ require 'cgi' # for escapeHTML
     </p>
 
     <p>
-      To create a new organization, you have to be logged in at <a href="https://tmc.mooc.fi" target="_blank">https://tmc.mooc.fi</a>. Note that user accounts created for the public-for-all MOOC-version of the service (<a href="https://tmc.mooc.fi/mooc" target="_blank">https://tmc.mooc.fi/mooc</a>) are not available in this version of the service. If needed, click the <em>Sign up</em> link and create your personal account. When logged in, go to url </i>/org/new</i> in the TMC system, (for example <a href="http://tmc.mooc.fi/org/new" target="_blank">http://tmc.mooc.fi/org/new</a>).
+      To create a new organization, you have to be logged in at <a href="https://tmc.mooc.fi" target="_blank">https://tmc.mooc.fi</a>. If needed, click the <em>Sign up</em> link and create your personal account. When logged in, go to url </i>/org/new</i> in the TMC system, (for example <a href="http://tmc.mooc.fi/org/new" target="_blank">http://tmc.mooc.fi/org/new</a>).
     </p>
 
 <%
@@ -95,6 +95,7 @@ require 'cgi' # for escapeHTML
   visit '/setup/new'
   fill_in 'organization_name', with: 'Helsingin yliopisto'
   fill_in 'organization_information', with: 'University life'
+  fill_in 'organization_website', with: 'http://www.helsinki.fi'
   fill_in 'organization_slug', with: 'hy'
   fill_in 'organization_contact_information', with: 'Matti Meikäläinen'
   fill_in 'organization_phone', with: '+3584012345678'
@@ -106,10 +107,11 @@ require 'cgi' # for escapeHTML
 <p>
   You will then be presented with a form with following fields, all of which can be changed later:
   <ul>
-    <li><b>Name</b> of the organization that will be seen in the app</li>
-    <li><b>Description</b> of your organization, seen on this organization's page</li>
-    <li><b>Logo</b> for your organization, seen on this organization's page</li>
+    <li><b>Name</b> of the organization that will be seen in the TMC pages</li>
+    <li><b>Information</b>, a longer description of your organization, seen on this organization's page</li>
+    <li><b>Website</b> of your organization</li>
     <li><b>Organization ID</b>, a short word that will be part of your organization's url. You will have an opportunity to preview organization's url</li>
+    <li><b>Logo</b> for your organization, seen on this organization's page</li>
   </ul>
 </p>
 
@@ -156,7 +158,7 @@ require 'cgi' # for escapeHTML
 <h2>Adding new teachers</h2>
 
 <p>
-  As a teacher, you can list, add and remove teachers in your organization. From the organization front page, you can find link to list all the teachers. Remember that all teachers in the organization have same access rights as you. We recommend you add any Teaching Assistants etc. as <a href="#phase_4_assistants">Course assistants</a>.
+  As a teacher, you can list, add and remove teachers in your organization. From the organization front page, you can find link to list all the teachers. Remember that all teachers in the organization have same access rights as you. We recommend you add any Teaching Assistants etc. as <a href="#course_assistants">Course assistants</a>.
 </p>
 
 <%
@@ -265,7 +267,7 @@ require 'cgi' # for escapeHTML
 </p>
 
 <p>
-  For example, you can choose to have 80% of previous unlock condition, and weekly deadlines starting from 1.1.2017. By clicking "Fill and preview", you will see the settings in the preview section.
+  For example, you can choose to have 80% of previous unlock condition, and weekly deadlines starting from 1.1.2017. By clicking 'Fill and preview', you will see the settings in the preview section.
 </p>
 
 <%
@@ -308,7 +310,10 @@ require 'cgi' # for escapeHTML
 <%= screenshot %>
 
 <p>
-  The course is now ready. You can choose to publish the course right away, or keep it hidden and disabled until it is ready to be published later. Click either of the buttons, and you will be redirected to the course main page.
+  The course creation is now ready. However, depending on the server load and chosen template, the exercises might be still under processing. This might take up to one hour to be completed. During that, course is not publicly visible and exercise zip files are not accessible. You can still progress to course main page, and access the settings. The course will stay hidden until you decide to publish it.
+</p>
+<p>
+  If the server-side process was fast and ready, you can choose to publish the course right away, or keep it hidden and disabled until it is ready to be published later. Click either of the buttons, and you will be redirected to the course main page.
 </p>
 
 <%
@@ -347,6 +352,10 @@ require 'cgi' # for escapeHTML
 
 <p>
   If you want to use an external point awarding system, you can enter its URL to the 'Custom points URL' field. You can also use a template string that will generate the URL dynamically. For example, <code style='white-space: nowrap'>http://my-custom-points.io/%{user}</code> would show as <code style='white-space: nowrap'>http://my-custom-points.io/MyUsername</code> when viewed by the user <code>MyUsername</code>.
+</p>
+
+<p>
+  If external score board url is set, it is shown instead of general tmc points page, when students click 'View points' link in the course page.
 </p>
 
   <h2>Disabling the course</h2>


### PR DESCRIPTION
Full refresh on course create is slow because available points calculation takes long time. Now refresh supports ignoring slow operations, and when new course is made, first refresh is made without that slow part. Instead, full refresh is launched on own thread to finish later at background. Course also has information if the first initial refresh is done or not, to disable submissions etc. until available points are calculated.

Splitting the refresh allows the new course wizard to progress fast and show course timings without minutes of waiting and even possible server timeout.

For admins, the front page shows if there are any courses which are not successfully initially refreshed, so potential problems can be found.

Another update in this PR is on course timings, where unlock options are offered better from drop down menu.