### PR TITLE
Add the possibility for user to delete their account

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,10 +21,15 @@ class ApplicationController < ActionController::Base
   include BreadcrumbHelpers
   include EmbeddableHelper
   include AuthorizeCollectionHelper
+  include ApplicationHelper
   check_authorization
 
   rescue_from CanCan::AccessDenied do |_exception|
-    respond_access_denied
+    if current_user.guest?
+      redirect_to(login_path(return_to: return_to_link))
+    else
+      respond_access_denied
+    end
   end
 
   rescue_from ActiveRecord::RecordNotFound do |exception|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -85,40 +85,46 @@ class UsersController < ApplicationController
   end
 
   def send_verification_email
-    user = authenticate_current_user
+    user = User.find(params[:user_id])
+    raise 'Access denied' if user != current_user && !current_user.admin?
     raise 'Already verified' if user.email_verified?
     UserMailer.email_confirmation(user).deliver_now
     redirect_to root_path, notice: "Verification email sent to #{user.email}."
   end
 
   def verify_destroying_user
-    @user = authenticate_current_user
+    @user = authenticate_current_user_destroy
     token = VerificationToken.delete_user.find_by!(user: @user, token: params[:id])
   end
 
   def destroy_user
-    im_sure = params[:id]
+    im_sure = params[:im_sure]
     if im_sure != "1"
       redirect_to verify_destroying_user_url, notice: "Please check the checkbox after you have read the instructions."
-    else
-      user = authenticate_current_user
-      token = VerificationToken.delete_user.find_by!(user: user, token: params[:id])
-      username = user.login
-      sign_out if current_user == user
-      user.destroy
-      redirect_to root_url, notice: "The account #{username} has been permanently destroyed."
+      return
     end
+    user = authenticate_current_user_destroy
+    user_authentication = User.authenticate(user.login, params[:user][:password])
+    if user_authentication.nil?
+      redirect_to verify_destroying_user_url, { alert: "The password was incorrect." }
+      return
+    end
+    token = VerificationToken.delete_user.find_by!(user: user, token: params[:id])
+    username = user.login
+    sign_out if current_user == user
+    user.destroy
+    redirect_to root_url, notice: "The account #{username} has been permanently destroyed."
   end
 
   def send_destroy_email
-    user = authenticate_current_user
+    user = authenticate_current_user_destroy
     UserMailer.destroy_confirmation(user).deliver_now
     redirect_to root_path, notice: "Verification email sent to #{user.email}."
   end
 
   private
 
-  def authenticate_current_user
+  def authenticate_current_user_destroy
     user = User.find(params[:user_id])
     authorize! :destroy, user
     user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -97,12 +97,17 @@ class UsersController < ApplicationController
   end
 
   def destroy_user
-    user = authenticate_current_user
-    token = VerificationToken.delete_user.find_by!(user: user, token: params[:id])
-    username = user.login
-    sign_out if current_user == user
-    user.destroy
-    redirect_to root_url, notice: "The account #{username} has been permanently destroyed."
+    im_sure = params[:id]
+    if im_sure != "1"
+      redirect_to verify_destroying_user_url, notice: "Please check the checkbox after you have read the instructions."
+    else
+      user = authenticate_current_user
+      token = VerificationToken.delete_user.find_by!(user: user, token: params[:id])
+      username = user.login
+      sign_out if current_user == user
+      user.destroy
+      redirect_to root_url, notice: "The account #{username} has been permanently destroyed."
+    end
   end
 
   def send_destroy_email

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -6,6 +6,13 @@ class UserMailer < ActionMailer::Base
     mail(from: SiteSetting.value('emails')['from'], to: user.email, subject: "Confirm your TestMyCode Account email address")
   end
 
+  def destroy_confirmation(user)
+    @user = user
+    token = user.verification_tokens.delete_user.create!
+    @url = base_url + verify_destroying_user_path(@user.id, token.token)
+    mail(from: SiteSetting.value('emails')['from'], to: user.email, subject: "Confirm deleting your TestMyCode account")
+  end
+
 
   private
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -37,6 +37,11 @@ class Ability
       end
 
       can :create, User if SiteSetting.value(:enable_signup)
+      cannot :destroy, User
+      can :destroy, User do |u|
+        user.administrator? ||
+        u == user
+      end
 
       cannot :read, Course
       can :read, Course do |c|

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -39,7 +39,6 @@ class Ability
       can :create, User if SiteSetting.value(:enable_signup)
       cannot :destroy, User
       can :destroy, User do |u|
-        user.administrator? ||
         u == user
       end
 

--- a/app/models/verification_token.rb
+++ b/app/models/verification_token.rb
@@ -4,7 +4,7 @@ class VerificationToken < ActiveRecord::Base
 
   belongs_to :user
 
-  enum type: [:email]
+  enum type: [:email, :delete_user]
 
   validates :type, presence: true
   validates :user, presence: true

--- a/app/views/user_mailer/destroy_confirmation.html.erb
+++ b/app/views/user_mailer/destroy_confirmation.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  </head>
+  <body>
+    <p>Hello!</p>
+
+    <p>You have requested deleting your TestMyCode account "<%= @user.login %>".</p>
+
+    <p>Please proceed to the following link to continue the deletion process.</p>
+
+    <a href="<%= @url %>"><%= @url %></a>
+
+    <p>If you didn't request deleting your account, just ignore this message.</p>
+  </body>
+</html>

--- a/app/views/user_mailer/destroy_confirmation.text.erb
+++ b/app/views/user_mailer/destroy_confirmation.text.erb
@@ -1,0 +1,9 @@
+Hello!
+
+You have requested deleting your TestMyCode account "<%= @user.login %>".
+
+Please proceed to the following link to continue the deletion process.
+
+<%= @url %>
+
+If you didn't request deleting your account, just ignore this message.

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,4 +4,6 @@
 
 <%= render :partial => 'users/form', :user => @user %>
 
-<%= button_to 'Request deleting account', send_destroy_email_path(@user.id), method: :post, class: 'btn btn-danger' %>
+<% if can? :destroy, @user %>
+  <%= button_to 'Request deleting account', send_destroy_email_path(@user.id), method: :post, class: 'btn btn-danger' %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,3 +3,5 @@
 <h1><%= @user.login %></h1>
 
 <%= render :partial => 'users/form', :user => @user %>
+
+<%= button_to 'Request deleting account', send_destroy_email_path(@user.id), method: :post, class: 'btn btn-danger' %>

--- a/app/views/users/verify_destroying_user.html.erb
+++ b/app/views/users/verify_destroying_user.html.erb
@@ -5,7 +5,7 @@
     <ul>
       <li>You will lose all your acquired exercise points. We will not be able to recover them.</li>
       <li>You will not be able to receive a grade from any TestMyCode course.</li>
-      <li>We will not be able to verify the authencity of any certificates that you have generated.</li>
+      <li>We will not be able to verify the authenticity of any certificates that you have generated.</li>
     <ul>
 </div>
 

--- a/app/views/users/verify_destroying_user.html.erb
+++ b/app/views/users/verify_destroying_user.html.erb
@@ -1,21 +1,24 @@
 <h1>Deleting the account <%= @user.login %></h1>
 
-<div class="alert alert-danger">
+<div class="jumbotron hero-unit-alert alert-danger">
   Deleting your account will have the following consequences:
     <ul>
       <li>You will lose all your acquired exercise points. We will not be able to recover them.</li>
-      <li>You will not be able to receive a grade from any TestMyCode course.</li>
+      <li>You will not be able to receive a grade from any course that uses TestMyCode.</li>
       <li>We will not be able to verify the authenticity of any certificates that you have generated.</li>
     <ul>
 </div>
 
-<p><strong>Pressing the button below will permanently destroy your TestMyCode account.</strong></p>
 
 <%= form_tag(destroy_user_path, method: :delete, class: 'form-horizontal') do  %>
   <div class="form-group">
     <%= check_box_tag :im_sure %>
     <%= label_tag "I've read the above and I'm sure I understand the consequences", nil, class: "control-label", for: :im_sure %>
   </div>
+  <div class="form-group">
+    <%= bs_labeled_field("Your password", password_field(:user, :password, :autocomplete => 'off', class: 'form-control')) %>
+  </div>
+  <p><strong>Pressing the button below will permanently destroy your TestMyCode account.</strong></p>
   <%= submit_tag("Destroy my account permanently", class: "btn btn-danger", data: { confirm: "Are you sure you want to delete the account #{@user.login}?"}, disabled: "disabled", id: :destroy_button) %>
 <% end %>
 

--- a/app/views/users/verify_destroying_user.html.erb
+++ b/app/views/users/verify_destroying_user.html.erb
@@ -1,0 +1,29 @@
+<h1>Deleting the account <%= @user.login %></h1>
+
+<div class="alert alert-danger">
+  Deleting your account will have the following consequences:
+    <ul>
+      <li>You will lose all your acquired exercise points. We will not be able to recover them.</li>
+      <li>You will not be able to receive a grade from any TestMyCode course.</li>
+      <li>We will not be able to verify the authencity of any certificates that you have generated.</li>
+    <ul>
+</div>
+
+<p><strong>Pressing the button below will permanently destroy your TestMyCode account.</strong></p>
+
+<%= form_tag(destroy_user_path, method: :delete, class: 'form-horizontal') do  %>
+  <div class="form-group">
+    <%= check_box_tag :im_sure %>
+    <%= label_tag "I've read the above and I'm sure I understand the consequences", nil, class: "control-label", for: :im_sure %>
+  </div>
+  <%= submit_tag("Destroy my account permanently", class: "btn btn-danger", data: { confirm: "Are you sure you want to delete the account #{@user.login}?"}, disabled: "disabled", id: :destroy_button) %>
+<% end %>
+
+
+<script>
+  var checkBox = document.getElementById('im_sure')
+  var destroyButton = document.getElementById('destroy_button')
+  checkBox.addEventListener("click", function() {
+    destroyButton.disabled = !checkBox.checked
+  })
+</script>

--- a/bin/spec_integration
+++ b/bin/spec_integration
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-RSPEC_PATTERN="spec/integration/**/*.rb"
+RSPEC_PATTERN="spec/integration/destroying_user_spec.rb"
 bundle exec rake spec SPEC_OPTS="--pattern $RSPEC_PATTERN --format documentation"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -230,6 +230,10 @@ TmcServer::Application.routes.draw do
   get '/users/:user_id/verify/:id', to: 'users#confirm_email', as: 'confirm_email'
   post '/users/:user_id/send_verification_email', to: 'users#send_verification_email', as: 'send_verification_email'
 
+  post '/users/:user_id/send_destroy_email', to: 'users#send_destroy_email', as: 'send_destroy_email'
+  get '/users/:user_id/destroy/:id', to: 'users#verify_destroying_user', as: 'verify_destroying_user'
+  delete '/users/:user_id/destroy/:id/destroy_user', to: 'users#destroy_user', as: 'destroy_user'
+
   resources :certificates, only: [:show, :create]
 
   resources :emails, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -232,7 +232,7 @@ TmcServer::Application.routes.draw do
 
   post '/users/:user_id/send_destroy_email', to: 'users#send_destroy_email', as: 'send_destroy_email'
   get '/users/:user_id/destroy/:id', to: 'users#verify_destroying_user', as: 'verify_destroying_user'
-  delete '/users/:user_id/destroy/:id/destroy_user', to: 'users#destroy_user', as: 'destroy_user'
+  delete '/users/:user_id/destroy/:id', to: 'users#destroy_user', as: 'destroy_user'
 
   resources :certificates, only: [:show, :create]
 

--- a/spec/integration/destroying_user_spec.rb
+++ b/spec/integration/destroying_user_spec.rb
@@ -1,0 +1,130 @@
+require 'spec_helper'
+
+describe "Deleting own user", type: :request, integration: true do
+  include IntegrationTestActions
+
+  it 'sending email should generate token' do
+    user = User.create!(login: 'user', password: 'password', email: 'theuser@example.com')
+
+    visit '/'
+    log_in_as('user', 'password')
+
+    visit '/user'
+
+    click_button 'Request deleting account'
+
+    # Yay, you got mail!
+
+    token = user.verification_tokens.delete_user[0]
+
+    expect(token.nil? == false)
+    expect(User.find_by(login: user.login) == user)
+  end
+
+  it 'verify destroy page should have a verification button and password field' do
+    user = User.create!(login: 'user', password: 'password', email: 'theuser@example.com')
+
+    visit '/'
+    log_in_as('user', 'password')
+
+    visit '/user'
+
+    click_button 'Request deleting account'
+
+    # Yay, you got mail!
+
+    token = user.verification_tokens.delete_user[0]
+
+    visit"/users/#{user.id}/destroy/#{token.token}"
+
+    expect(page).to have_content("Deleting the account #{user.login}")
+
+    expect(page).to have_button('Destroy my account permanently', disabled: true)
+
+    check "I've read the above and i'm sure i understand the consequences"
+
+    expect(page).to have_button('Destroy my account permanently', disabled: false)
+    expect(User.find_by(login: user.login) == user)
+    expect(page).to have_content('Your password')
+  end
+
+  it 'pressing verification button destroys user' do
+    user = User.create!(login: 'user', password: 'password', email: 'theuser@example.com')
+    username = user.login
+
+    visit '/'
+    log_in_as('user', 'password')
+
+    visit '/user'
+
+    click_button 'Request deleting account'
+
+    # Yay, you got mail!
+
+    token = user.verification_tokens.delete_user[0]
+
+    visit"/users/#{user.id}/destroy/#{token.token}"
+
+    check "I've read the above and i'm sure i understand the consequences"
+
+    fill_in 'user[password]', with: user.password
+
+    click_button 'Destroy my account permanently'
+
+    page.accept_alert
+
+    expect { User.find_by!(login: username) }.to raise_error ActiveRecord::RecordNotFound
+    expect(page).to have_content("The account #{username} has been permanently destroyed")
+  end
+
+  it 'will not destroy user if password incorrect' do
+    user = User.create!(login: 'user', password: 'password', email: 'theuser@example.com')
+
+    visit '/'
+    log_in_as('user', 'password')
+
+    visit '/user'
+
+    click_button 'Request deleting account'
+
+    # Yay, you got mail!
+
+    token = user.verification_tokens.delete_user[0]
+
+    visit"/users/#{user.id}/destroy/#{token.token}"
+
+    check "I've read the above and i'm sure i understand the consequences"
+
+    fill_in 'user[password]', with: 'thisiswrongpassword'
+
+    click_button 'Destroy my account permanently'
+
+    page.accept_alert
+
+    expect(User.find_by(login: user.login) == user)
+    expect(page).to have_content('The password was incorrect')
+  end
+
+  it 'cannot be verified by another user' do
+    user1 = User.create!(login: 'user1', password: 'password1', email: 'user1@example.com')
+    user2 = User.create!(login: 'user2', password: 'password2', email: 'user2@example.com')
+
+    visit '/'
+    log_in_as('user1', 'password1')
+
+    visit '/user'
+
+    click_button 'Request deleting account'
+
+    log_out
+
+    log_in_as('user2', 'password2')
+
+    token = user1.verification_tokens.delete_user[0]
+
+    visit "/users/#{user1.id}/destroy/#{token.token}"
+
+    expect(page).to have_content("Access denied")
+  end
+
+end

--- a/spec/support/integration_test_actions.rb
+++ b/spec/support/integration_test_actions.rb
@@ -15,7 +15,7 @@ module IntegrationTestActions
   end
 
   def log_out
-    click_link 'Sign out'
+    visit '/logout'
   end
 
   def create_new_course(options = {})


### PR DESCRIPTION
The user has a button on their settings tab. Pressing the button will send them a verification email containing a link, with a unique token (which expires in a week). On that page on has to give the password of the user to be deleted, and check a checkbox making sure that they understand the consequences of deleting their account.

At the moment a user can only delete their own account (even admins).