### PR TITLE
Handle internal sandbox errors with submissions

### DIFF
--- a/app/models/remote_sandbox.rb
+++ b/app/models/remote_sandbox.rb
@@ -90,13 +90,16 @@ class RemoteSandbox
         rescue StandardError
           raise SandboxUnavailableError
         end
+        if @parsed['status']
+          # If sandbox returns status key, it is busy and unavailable.
+          raise SandboxUnavailableError
+        end
         raise InternalSandboxError.new(@parsed['error'])
       end
     rescue SandboxUnavailableError
       raise
     rescue InternalSandboxError => e
       submission.pretest_error = e.object
-      submission.processed = true
       submission.save!
       raise
     rescue StandardError

--- a/lib/submission_processor.rb
+++ b/lib/submission_processor.rb
@@ -27,7 +27,12 @@ class SubmissionProcessor
       if submission.times_sent_to_sandbox < Submission.max_attempts_at_processing
         process_submission(submission)
       else
-        submission.pretest_error = "Tried to process #{Submission.max_attempts_at_processing} times but failed. This is a system error"
+        msg = "Tried to process #{Submission.max_attempts_at_processing} times but failed. This is a system error"
+        if submission.pretest_error
+          submission.pretest_error = msg + "\n" + submission.pretest_error
+        else
+          submission.pretest_error = msg
+        end
         Rails.logger.warn "Submission #{submission.id} marked permanently failed."
         submission.processed = true
         submission.secret_token = nil


### PR DESCRIPTION
Set error originating from sandbox like `Docker image was not whitelisted.` as submission result to prevent infinite submission reprocessing.

~~This does not resolve the issue of containers failing to run in local environment due to the above error.~~