### PR TITLE
Refactor: can use MOOC.fi tokens to authenticate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ group :development, :test do
   gem 'pry'
   gem 'pry-byebug'
   gem 'pry-rails'
-
+  gem 'solargraph' # vscode
   gem 'database_cleaner', '~> 2.0'
   gem 'launchy' # for capybara's save_and_open_page
   gem 'mimic', '~> 0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,8 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.2.5.0)
       execjs (< 2.8.0)
+    backport (1.2.0)
+    benchmark (0.1.1)
     bootstrap (4.6.0)
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.14.3, < 2)
@@ -114,6 +116,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     doorkeeper (5.5.1)
       railties (>= 5)
+    e2mmap (0.1.0)
     erubi (1.10.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
@@ -182,6 +185,7 @@ GEM
     io-console (0.5.9)
     irb (1.3.5)
       reline (>= 0.1.5)
+    jaro_winkler (1.5.4)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -190,6 +194,10 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jwt (2.2.3)
+    kramdown (2.3.1)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     launchy (2.5.0)
       addressable (~> 2.7)
     letter_opener (1.7.0)
@@ -321,6 +329,8 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.2)
+    reverse_markdown (2.0.0)
+      nokogiri
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -403,6 +413,21 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.1.0)
       tilt (~> 2.0)
+    solargraph (0.43.0)
+      backport (~> 1.2)
+      benchmark
+      bundler (>= 1.17.2)
+      diff-lcs (~> 1.4)
+      e2mmap
+      jaro_winkler (~> 1.5)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      parser (~> 3.0)
+      reverse_markdown (>= 1.0.5, < 3)
+      rubocop (>= 0.52)
+      thor (~> 1.0)
+      tilt (~> 2.0)
+      yard (~> 0.9, >= 0.9.24)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -434,6 +459,7 @@ GEM
     xml-simple (1.1.8)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.26)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -494,6 +520,7 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   sassc-rails (~> 2.1)
   simplecov
+  solargraph
   sprockets-rails
   swagger-blocks (~> 3.0)
   uglifier (~> 4.2)

--- a/app/controllers/api/v8/base_controller.rb
+++ b/app/controllers/api/v8/base_controller.rb
@@ -35,9 +35,22 @@ module Api
 
       private
         def authenticate_user!
+          puts "current_user", @current_user
+          puts "token", bearer_token
+
           return @current_user if @current_user
+
           if doorkeeper_token
             @current_user ||= User.find_by(id: doorkeeper_token.resource_owner_id)
+            raise 'Invalid token' unless @current_user
+          else
+            moocfi_user = validate_moocfi_user
+            puts "moocfi_user", moocfi_user
+            raise 'Invalid token' unless moocfi_user
+
+            @current_user ||= User.find_by(id: moocfi_user['upstream_id']) if moocfi_user['upstream_id'] > 0 
+            @current_user ||= create_user_from_moocfi(moocfi_user) if not moocfi_user['upstream_id'] or moocfi_user['upstream_id'] < 0
+            puts "current_user after find or create", @current_user
             raise 'Invalid token' unless @current_user
           end
           @current_user ||= user_from_session || Guest.new
@@ -124,6 +137,73 @@ module Api
               nil # without version check
             end
           end
+        end
+
+        def bearer_token
+          pattern = /^Bearer /
+          authorization = request.authorization
+          authorization.gsub(pattern, '') if authorization && authorization.match(pattern)
+        end
+
+        def validate_moocfi_user
+          uri = URI('http://localhost:4000/auth/validate')
+          req = Net::HTTP::Get.new(uri)
+          req["Authorization"] = request.authorization
+
+          mooc_response = Net::HTTP.start(uri.hostname, uri.port) {|http|
+            res = http.request(req)
+            JSON.parse(res.body)
+          }
+          user = mooc_response["user"]
+          puts user
+          user 
+          # @current_user ||= user
+          # @current_user ||= User.new({
+          #   id: user.id,
+          #   login: user.username,
+          #   email: user.email
+          # })
+
+          # .find_by(id: mooc_response["user"]["upstream_id"])
+        end
+
+        def create_user_from_moocfi(moocfi_user)
+          puts "creating new user from", moocfi_user
+          user = User.new
+          user.login = SecureRandom.uuid
+          user.email = moocfi_user['email']
+          user.password = SecureRandom.base64(12)
+          user.administrator = moocfi_user['administrator'] || false
+
+          user.save!
+
+          first_name = UserFieldValue.new(field_name: 'first_name', user_id: user.id, value: moocfi_user['first_name'])
+          last_name = UserFieldValue.new(field_name: 'last_name', user_id: user.id, value: moocfi_user['last_name'])
+          # first_name = user.user_field_values.new(field_name: 'first_name', value: moocfi_user['first_name'])
+          # last_name = user.user_field_values.new(field_name: 'last_name', value: moocfi_user['last_name'])
+
+          first_name.save!
+          last_name.save!
+
+          puts "new user?", user.to_json
+
+          update_moocfi_user(user)
+
+          user
+        end 
+        
+        def update_moocfi_user(user)
+          uri = URI('http://localhost:4000/api/user/update-from-tmc')
+          req = Net::HTTP::Post.new(uri, initheader = { 'Content-Type' => 'application/json' })
+          req["Authorization"] = request.authorization
+          req.body = { upstream_id: user['id'] }.to_json
+
+          mooc_response = Net::HTTP.start(uri.hostname, uri.port) {|http|
+            http.request(req)
+          }
+          puts mooc_response.code
+          raise "Error updating MOOC.fi user" if mooc_response.code.to_i >= 400
+
         end
     end
   end

--- a/app/controllers/api/v8/base_controller.rb
+++ b/app/controllers/api/v8/base_controller.rb
@@ -45,7 +45,6 @@ module Api
             moocfi_user = validate_moocfi_user
             # raise 'Invalid token' unless moocfi_user
 
-            puts 'validated ok', moocfi_user
             @current_user ||= User.find_by(id: moocfi_user['upstream_id']) || create_or_update_user_from_moocfi(moocfi_user)
             # raise 'Invalid token' unless @current_user
           end
@@ -144,7 +143,6 @@ module Api
         def validate_moocfi_user
           base_url_for_moocfi = SiteSetting.value('base_url_for_moocfi')
 
-          puts 'I am validating'
           begin
             res = RestClient::Request.execute(method: :get, url: "#{base_url_for_moocfi}/auth/validate", headers: { 'Authorization': request.authorization })
             moocfi_response = JSON.parse(res.body)
@@ -157,7 +155,7 @@ module Api
         end
 
         def create_or_update_user_from_moocfi(moocfi_user)
-          # in case we have a disrepancy, ie. MOOC.fi user and TMC user both exist, but MOOC.fi user doesn't have TMC id
+          # in case we have a discrepancy, ie. MOOC.fi user and TMC user both exist, but MOOC.fi user doesn't have TMC id
           user = User.find_by(email: moocfi_user['email'])
 
           if user
@@ -187,14 +185,13 @@ module Api
         end
 
         def update_moocfi_user(user)
-          puts 'updating'
           base_url_for_moocfi = SiteSetting.value('base_url_for_moocfi')
           moocfi_update_secret = SiteSetting.value('moocfi_update_secret')
 
           begin
             res = RestClient::Request.execute(
-              method: :post, 
-              url: "#{base_url_for_moocfi}/api/user/update-from-tmc", 
+              method: :patch, 
+              url: "#{base_url_for_moocfi}/api/user", 
               payload: { 'upstream_id': user['id'], 'secret': moocfi_update_secret }.to_json,
               headers: {
                 'Authorization': request.authorization,

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -26,6 +26,7 @@ class SiteSetting
         raise "Invalid configuration file #{path}" unless data.is_a? Hash
         result = result.deep_merge(data)
       end
+      puts "settings", result
       result
     end
 

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -26,7 +26,6 @@ class SiteSetting
         raise "Invalid configuration file #{path}" unless data.is_a? Hash
         result = result.deep_merge(data)
       end
-      puts "settings", result
       result
     end
 

--- a/config/site.dev.yml
+++ b/config/site.dev.yml
@@ -20,3 +20,5 @@ valid_clients:
 kafka_bridge_url: "test"
 kafka_bridge_secret: "test"
 moocfi_service_id: "test"
+moocfi_update_secret: "test"
+base_url_for_moocfi: http://localhost:4000


### PR DESCRIPTION
- at first, tries the token as TMC token
  - if successful, then it is a TMC token and business as usual
  - if not, we contact MOOC.fi `validate` endpoint to see if it's a user there
    - if we have successful validation, we receive the MOOC.fi user and try to look for the user by id in TMC
      - if successful, we are validated
      - if not successful, we try to look for the user by email
        - if successful, we contact MOOC.fi `/api/user` endpoint to update the user `upstream_id` (ie. TMC id) there
        - if not successful, we create a new TMC user with the data, and update the user `upstream_id` in MOOC.fi
 