### PR TITLE
bugfix for firefox users

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -448,29 +448,9 @@ td.hljs-ln-numbers {
 	/* your custom style here */
 }
 
-/* 2022-01-01
-   BUG: Mozilla inserts newlines in text copied from code listing [https://bugzilla.mozilla.org/show_bug.cgi?id=1625534]
-   FIX: unset *user-select on mozilla browsers
-   (Uses CSS-hack described: [https://bugzilla.mozilla.org/show_bug.cgi?id=1446470]) */
-@-moz-document url-prefix() {
-  td.hljs-ln-numbers {
-    -webkit-user-select:unset;
-    -moz-user-select:unset;
-    -ms-user-select:unset;
-    user-select:unset;
-  }
-}
-
 /* for block of code */
 td.hljs-ln-code {
 	padding-left: 10px !important;
-}
-
-/* 2022-01-01
-   BUG: Mozilla inserts newlines when copying text before div blocks.
-   FIX: set display: inline-block on div.hljs-ln-line */
-div.hljs-ln-line {
-  display: inline-block
 }
 
 .course-card-link:hover {

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -448,9 +448,29 @@ td.hljs-ln-numbers {
 	/* your custom style here */
 }
 
+/* 2022-01-01
+   BUG: Mozilla inserts newlines in text copied from code listing [https://bugzilla.mozilla.org/show_bug.cgi?id=1625534]
+   FIX: unset *user-select on mozilla browsers
+   (Uses CSS-hack described: [https://bugzilla.mozilla.org/show_bug.cgi?id=1446470]) */
+@-moz-document url-prefix() {
+  td.hljs-ln-numbers {
+    -webkit-user-select:unset;
+    -moz-user-select:unset;
+    -ms-user-select:unset;
+    user-select:unset;
+  }
+}
+
 /* for block of code */
 td.hljs-ln-code {
 	padding-left: 10px !important;
+}
+
+/* 2022-01-01
+   BUG: Mozilla inserts newlines when copying text before div blocks.
+   FIX: set display: inline-block on div.hljs-ln-line */
+div.hljs-ln-line {
+  display: inline-block
 }
 
 .course-card-link:hover {

--- a/app/assets/stylesheets/submissions.css
+++ b/app/assets/stylesheets/submissions.css
@@ -1,3 +1,27 @@
 /* ...
 *= require_self
 */
+
+/* 2022-01-01
+  BUG: Mozilla inserts newlines in text copied from code listing [https://bugzilla.mozilla.org/show_bug.cgi?id=1625534]
+  FIX: unset *user-select on mozilla browsers
+  (Uses CSS-hack described: [https://bugzilla.mozilla.org/show_bug.cgi?id=1446470])
+*/
+
+@-moz-document url-prefix() {
+  td.hljs-ln-numbers {
+    -webkit-user-select: unset;
+    -moz-user-select: unset;
+    -ms-user-select: unset;
+    user-select: unset;
+  }
+}
+
+/* 2022-01-01
+  BUG: Mozilla inserts newlines when copying text before div blocks.
+  FIX: set display: inline-block on div.hljs-ln-line
+*/
+
+div.hljs-ln-line {
+  display: inline-block;
+}


### PR DESCRIPTION
BUG: Firefox inserts newlines between each line when code is copied from a code listing in a TMC paste page.
FIX: Two problems in the CSS, each of which independently cause the above issue.

Note: This fix has only been tested using local copies of the generated html pages -- I haven't spun up an instance of tmc-server to properly test it. This might not even be the correct place in the source tree to fix it.

Fixes #548 