### PR TITLE
Fix incorrect pluralization in toast

### DIFF
--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,6 +1,6 @@
 <% if current_user.administrator? && !Organization.pending_organizations.empty? %>
   <div class="alert alert-warning" role="alert">
-    <%= pluralize(Organization.pending_organizations.size, 'new organization to verify') %>.
+    <%= pluralize(Organization.pending_organizations.size, 'new organization') %> to verify.
     <%= link_to 'Show', list_requests_organizations_path %>
   </div>
 <% end %>


### PR DESCRIPTION
**NB: Not tested locally, please verify before merging.**

This changes the "new organization to verify" toast visible to admins from "17 new organization to verifies" to grammatically more correct "17 new organizations to verify".