### PR TITLE
Add memory and cpu limits to exercises

### DIFF
--- a/app/models/remote_sandbox.rb
+++ b/app/models/remote_sandbox.rb
@@ -77,6 +77,8 @@ class RemoteSandbox
             file: tar_file, notify: notify_url, token: submission.secret_token, submission_id: submission.id
           }
           payload[:docker_image] = exercise.docker_image if exercise.docker_image
+          payload[:memory_limit] = exercise.memory_limit if exercise.memory_limit
+          payload[:cpu_limit] = exercise.cpu_limit if exercise.cpu_limit
 
           RestClient::Request.execute(method: :post, url: post_url, timeout: 5, payload: payload)
         end

--- a/db/migrate/20240112130207_add_memory_and_cpu_limits_to_exercises.rb
+++ b/db/migrate/20240112130207_add_memory_and_cpu_limits_to_exercises.rb
@@ -1,0 +1,6 @@
+class AddMemoryAndCpuLimitsToExercises < ActiveRecord::Migration[6.1]
+  def change
+    add_column :exercises, :memory_limit_gb, :integer, default: 1, null: false
+    add_column :exercises, :cpu_limit, :integer, default: 1, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_10_232815) do
+ActiveRecord::Schema.define(version: 2024_01_12_130207) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -205,6 +205,8 @@ ActiveRecord::Schema.define(version: 2023_09_10_232815) do
     t.boolean "hide_submission_results", default: false
     t.string "docker_image", default: "eu.gcr.io/moocfi-public/tmc-sandbox-tmc-langs-rust"
     t.integer "paste_visibility"
+    t.integer "memory_limit_gb", default: 1, null: false
+    t.integer "cpu_limit", default: 1, null: false
     t.index ["course_id", "name"], name: "index_exercises_on_course_id_and_name", unique: true
     t.index ["gdocs_sheet"], name: "index_exercises_on_gdocs_sheet"
     t.index ["name"], name: "index_exercises_on_name"

--- a/lib/course_refresh_database_updater.rb
+++ b/lib/course_refresh_database_updater.rb
@@ -126,6 +126,30 @@ class CourseRefreshDatabaseUpdater
         end
       end
 
+      def set_memory_limit
+        @rust_data['exercises'].each do |exercise|
+          ex = @course.exercises.find { |e| e.name == exercise['name'] }
+          next unless ex
+          if (exercise['tmcproject-yml'] || {}).include? 'memory_gb'
+            ex.memory_limit = exercise['tmcproject-yml']['memory_gb']
+          else
+            ex.memory_limit = 1
+          end
+        end
+      end
+
+      def set_cpu_limit
+        @rust_data['exercises'].each do |exercise|
+          ex = @course.exercises.find { |e| e.name == exercise['name'] }
+          next unless ex
+          if (exercise['tmcproject-yml'] || {}).include? 'cpus'
+            ex.cpu_limit = exercise['tmcproject-yml']['cpus']
+          else
+            ex.cpu_limit = 1
+          end
+        end
+      end
+
       def update_available_points
         @rust_data['exercises'].each do |exercise|
           added = []


### PR DESCRIPTION
Add memory_limit_gb and cpu_limit to exercises, default values are 1 for both (1GB of memory and 1 cpu thread). These are used on sandbox when running tests for the exercise. Both values can be customized through .tmcproject.yml.