### PR TITLE
Add submission processing limit for users

### DIFF
--- a/app/controllers/api/v8/core/exercises/submissions_controller.rb
+++ b/app/controllers/api/v8/core/exercises/submissions_controller.rb
@@ -54,6 +54,13 @@ module Api
               return respond_forbidden('Submissions for this exercise are no longer accepted.')
             end
 
+            # Check if user has too many processing submissions for this exercise
+            processing_count = current_user.processing_submissions_count_for_exercise(@exercise.name, @course.id)
+            if processing_count >= 3
+              authorization_skip!
+              return respond_forbidden("Too many submissions currently processing for this exercise. You have #{processing_count} submissions being processed. Please wait for them to complete before submitting again. All your submissions will eventually get processed and you will get your points.")
+            end
+
             file_contents = File.read(params[:submission][:file].tempfile.path)
 
             errormsg = nil

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -116,6 +116,16 @@ class Submission < ApplicationRecord
     unprocessed.count
   end
 
+  # Count how many submissions a user has processing for a specific exercise
+  def self.processing_count_for_user_and_exercise(user_id, exercise_name, course_id)
+    where(
+      user_id: user_id,
+      exercise_name: exercise_name,
+      course_id: course_id,
+      processed: false
+    ).count
+  end
+
   # How many times at most should a submission be (successfully) sent to a sandbox
   def self.max_attempts_at_processing
     3

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -280,6 +280,11 @@ class User < ApplicationRecord
     User.where('lower(email) LIKE ?', "%#{query.strip.downcase}%")
   end
 
+  # Count how many submissions this user has processing for a specific exercise
+  def processing_submissions_count_for_exercise(exercise_name, course_id)
+    Submission.processing_count_for_user_and_exercise(id, exercise_name, course_id)
+  end
+
   private
     def course_ids_arel
       courses = Course.arel_table


### PR DESCRIPTION
* Implemented a check in the submissions controller to limit users to a maximum of 3 processing submissions for a specific exercise.
* Added a method in the User model to count processing submissions for an exercise.
* Introduced a corresponding method in the Submission model to facilitate this count.